### PR TITLE
adding minecraft chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # minecraft-server-charts
+
+[![](https://github.com/itzg/minecraft-server-charts/workflows/Release%20Charts/badge.svg?branch=master)](https://github.com/itzg/minecraft-server-charts/actions)
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```console
+helm repo add itzg https://itzg.github.io/minecraft-server-charts/
+```
+
+You can then run `helm search repo itzg` to see the charts.
+
+## Charts
+
+* [minecraft](https://itzg.github.io/minecraft-server-charts)
+
+```bash
+helm install --name your-release itzg/minecraft
+```
+
+Also see [helm hub](https://hub.helm.sh/charts/itzg) for a complete list.

--- a/charts/minecraft/.helmignore
+++ b/charts/minecraft/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+name: minecraft
+version: 2.0.0
+appVersion: 1.14.4
+home: https://minecraft.net/
+description: Minecraft server
+keywords:
+- game
+- server
+sources:
+- https://github.com/itzg/minecraft-server-charts
+- https://hub.docker.com/r/itzg/minecraft-server/~/dockerfile/
+- https://github.com/itzg/dockerfiles
+maintainers:
+- name: gtaylor
+  email: gtaylor@gc-taylor.com
+- name: billimek
+  email: jeff@billimek.com
+- name: itzg
+  email: itzgeoff@gmail.com

--- a/charts/minecraft/OWNERS
+++ b/charts/minecraft/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- gtaylor
+- itzg
+- billimek
+reviewers:
+- gtaylor
+- itzg
+- billimek

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -1,0 +1,78 @@
+# Minecraft
+
+[Minecraft](https://minecraft.net/en/) is a game about placing blocks and going on adventures.
+
+## Introduction
+
+This chart creates a single Minecraft Pod, plus Services for the Minecraft server and RCON.
+
+## Prerequisites
+
+- 512 MB of RAM
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `minecraft`, read the [Minecraft EULA](https://account.mojang.com/documents/minecraft_eula) run:
+
+```shell
+helm install minecraft \
+  --set minecraftServer.eula=true itzg/minecraft
+```
+
+This command deploys a Minecraft dedicated server with sensible defaults.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `minecraft` deployment:
+
+```shell
+helm delete minecraft
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Refer to [values.yaml](values.yaml) for the full run-down on defaults. These are a mixture of Kubernetes and Minecraft-related directives that map to environment variables in the [itzg/minecraft-server](https://hub.docker.com/r/itzg/minecraft-server/) Docker image.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```shell
+helm install --name minecraft \
+  --set minecraftServer.eula=true,minecraftServer.Difficulty=hard \
+  itzg/minecraft
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```shell
+helm install --name minecraft -f values.yaml itzg/minecraft
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+The [itzg/minecraft-server](https://hub.docker.com/r/itzg/minecraft-server/) image stores the saved games and mods under /data.
+
+By default a PersistentVolumeClaim is created and mounted for saves but not mods. In order to disable this functionality
+you can change the values.yaml to disable persistence under the sub-sections under `persistence`.
+
+> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
+
+## Backups
+
+You can backup the state of your minecraft server to your local machine via the `kubectl cp` command.  
+
+```shell
+NAMESPACE=default
+POD_ID=lionhope-387ff8d-sdis9
+kubectl exec --namespace ${NAMESPACE} ${POD_ID} rcon-cli save-off
+kubectl exec --namespace ${NAMESPACE} ${POD_ID} rcon-cli save-all
+kubectl cp ${NAMESPACE}/${POD_ID}:/data .
+kubectl exec --namespace ${NAMESPACE} ${POD_ID} rcon-cli save-on
+```

--- a/charts/minecraft/ci/test-values.yaml
+++ b/charts/minecraft/ci/test-values.yaml
@@ -1,0 +1,3 @@
+# This must be overridden, since we can't accept this for the user.
+minecraftServer.eula: "TRUE"
+# fix in place and rebased

--- a/charts/minecraft/templates/NOTES.txt
+++ b/charts/minecraft/templates/NOTES.txt
@@ -1,0 +1,51 @@
+{{- if eq (printf "%s" .Values.minecraftServer.eula) "FALSE" }}
+##############################################################################
+####   ERROR: You did not agree to the EULA in your 'helm install' call.  ####
+##############################################################################
+
+This deployment will be incomplete until you read the Minecraft EULA linked
+in the README.md, then:
+
+    helm upgrade {{ .Release.Name }} \
+        --set minecraftServer.eula=true stable/minecraft
+{{- else -}}
+
+Get the IP address of your Minecraft server by running these commands in the
+same shell:
+
+{{- if contains "NodePort" .Values.minecraftServer.serviceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} \
+    -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "minecraft.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} \
+    -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "You'll need to expose this node through your security groups/firewall"
+  echo "for it to be world-accessible."
+  echo $NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.minecraftServer.serviceType }}
+
+!! NOTE: It may take a few minutes for the LoadBalancer IP to be available. !!
+
+You can watch for EXTERNAL-IP to populate by running:
+  kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "minecraft.fullname" . }}
+
+{{- else if contains "ClusterIP" .Values.minecraftServer.serviceType }}
+  export POD_NAME=$(kubectl get pods \
+    --namespace {{ .Release.Namespace }} \
+    -l "component={{ template "minecraft.fullname" . }}" \
+    -o jsonpath="{.items[0].metadata.name}")
+  kubectl port-forward $POD_NAME 25565:25565
+  echo "Point your Minecraft client at 127.0.0.1:22565"
+
+{{- end }}
+
+{{- if .Values.persistence.dataDir.enabled }}
+{{- else }}
+
+############################################################################
+###   WARNING: Persistence is disabled!!! You will lose your game state  ###
+###                when the Minecraft pod is terminated.                 ###
+###      See values.yaml's persistence.dataDir.enabled directive.        ###
+############################################################################
+{{- end }}
+{{- end }}

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "minecraft.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "minecraft.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/minecraft/templates/datadir-pvc.yaml
+++ b/charts/minecraft/templates/datadir-pvc.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim ) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "minecraft.fullname" . }}-datadir
+  labels:
+    app: {{ template "minecraft.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.dataDir.Size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -1,0 +1,224 @@
+{{- if ne (printf "%s" .Values.minecraftServer.eula) "FALSE" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "minecraft.fullname" . }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- range $key, $value := .Values.deploymentAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app: {{ template "minecraft.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  strategy:
+    type: {{ .Values.strategyType }}
+  selector:
+    matchLabels:
+      app: {{ template "minecraft.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "minecraft.fullname" . }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      containers:
+      - name: {{ template "minecraft.fullname" . }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: Always
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        readinessProbe:
+          exec:
+            command: 
+{{ toYaml .Values.readinessProbe.command | indent 14 }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+        livenessProbe:
+          exec:
+            command:
+{{ toYaml .Values.livenessProbe.command | indent 14 }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        env:
+        - name: EULA
+          value: {{ .Values.minecraftServer.eula | quote }}
+        - name: TYPE
+          value: {{ default "" .Values.minecraftServer.type | quote }}
+        {{- if eq .Values.minecraftServer.type "FORGE" }}
+        {{- if .Values.minecraftServer.forgeInstallerUrl }}
+        - name: FORGE_INSTALLER_URL
+          value: {{ .Values.minecraftServer.forgeInstallerUrl | quote }}
+        {{- else }}
+        - name: FORGEVERSION
+          value: {{ .Values.minecraftServer.forgeVersion | quote }}
+        {{- end }}
+        {{- else if eq .Values.minecraftServer.type "SPIGOT" }}
+        - name: SPIGOT_DOWNLOAD_URL
+          value: {{ .Values.minecraftServer.spigotDownloadUrl | quote }}
+        {{- else if eq .Values.minecraftServer.type "BUKKIT" }}
+        - name: BUKKIT_DOWNLOAD_URL
+          value: {{ .Values.minecraftServer.bukkitDownloadUrl | quote }}
+        {{- else if eq .Values.minecraftServer.type "PAPER" }}
+        - name: PAPER_DOWNLOAD_URL
+          value: {{ .Values.minecraftServer.paperDownloadUrl | quote }}
+        {{- else if eq .Values.minecraftServer.type "FTB" }}
+        - name: FTB_SERVER_MOD
+          value: {{ .Values.minecraftServer.ftbServerMod | quote }}
+        - name: FTB_LEGACYJAVAFIXER
+          value: {{ default false .Values.minecraftServer.ftbLegacyJavaFixer | quote }}
+        {{- end }}
+        - name: VERSION
+          value: {{ .Values.minecraftServer.version | quote }}
+        - name: DIFFICULTY
+          value: {{ .Values.minecraftServer.difficulty | quote }}
+        - name: WHITELIST
+          value: {{ default "" .Values.minecraftServer.whitelist | quote }}
+        - name: OPS
+          value: {{ default "" .Values.minecraftServer.ops | quote }}
+        - name: ICON
+          value: {{ default "" .Values.minecraftServer.icon | quote }}
+        - name: MAX_PLAYERS
+          value: {{ .Values.minecraftServer.maxPlayers | quote }}
+        - name: MAX_WORLD_SIZE
+          value: {{ .Values.minecraftServer.maxWorldSize | quote }}
+        - name: ALLOW_NETHER
+          value: {{ .Values.minecraftServer.allowNether | quote }}
+        - name: ANNOUNCE_PLAYER_ACHIEVEMENTS
+          value: {{ .Values.minecraftServer.announcePlayerAchievements | quote }}
+        - name: ENABLE_COMMAND_BLOCK
+          value: {{ .Values.minecraftServer.enableCommandBlock | quote }}
+        - name: FORCE_gameMode
+          value: {{ .Values.minecraftServer.forcegameMode | quote }}
+        {{- if .Values.minecraftServer.forceReDownload }}
+        - name: FORCE_REDOWNLOAD
+          value: "TRUE"
+        {{- end }}
+        - name: GENERATE_STRUCTURES
+          value: {{ .Values.minecraftServer.generateStructures | quote }}
+        - name: HARDCORE
+          value: {{ .Values.minecraftServer.hardcore | quote }}
+        - name: MAX_BUILD_HEIGHT
+          value: {{ .Values.minecraftServer.maxBuildHeight | quote }}
+        - name: MAX_TICK_TIME
+          value: {{ .Values.minecraftServer.maxTickTime | quote }}
+        - name: SPAWN_ANIMALS
+          value: {{ .Values.minecraftServer.spawnAnimals | quote }}
+        - name: SPAWN_MONSTERS
+          value: {{ .Values.minecraftServer.spawnMonsters | quote }}
+        - name: SPAWN_NPCS
+          value: {{ .Values.minecraftServer.spawnNPCs | quote }}
+        - name: VIEW_DISTANCE
+          value: {{ .Values.minecraftServer.viewDistance | quote }}
+        - name: SEED
+          value: {{ default "" .Values.minecraftServer.levelSeed | quote }}
+        - name: MODE
+          value: {{ .Values.minecraftServer.gameMode | quote }}
+        - name: MOTD
+          value: {{ .Values.minecraftServer.motd | quote }}
+        - name: PVP
+          value: {{ .Values.minecraftServer.pvp | quote }}
+        - name: LEVEL_TYPE
+          value: {{ .Values.minecraftServer.levelType | quote }}
+        - name: GENERATOR_SETTINGS
+          value: {{ default "" .Values.minecraftServer.generatorSettings | quote }}
+        - name: LEVEL
+          value: {{ .Values.minecraftServer.worldSaveName | quote }}
+        {{- if .Values.minecraftServer.downloadWorldUrl }}
+        - name: WORLD
+          value: {{ .Values.minecraftServer.downloadWorldUrl | quote }}
+        {{- end }}
+        {{- if .Values.minecraftServer.downloadModpackUrl }}
+        - name: MODPACK
+          value: {{ .Values.minecraftServer.downloadModpackUrl | quote }}
+        {{- if .Values.minecraftServer.removeOldMods }}
+        - name: REMOVE_OLD_MODS
+          value: "TRUE"
+        {{- end }}
+        {{- end }}
+        - name: ONLINE_MODE
+          value: {{ .Values.minecraftServer.onlineMode | quote }}
+        - name: MEMORY
+          value: {{ .Values.minecraftServer.memory | quote }}
+        - name: JVM_OPTS
+          value: {{ .Values.minecraftServer.jvmOpts | quote }}
+        - name: JVM_XX_OPTS
+          value: {{ .Values.minecraftServer.jvmXXOpts | quote }}
+
+        {{- if .Values.minecraftServer.rcon.enabled }}
+        - name: ENABLE_RCON
+          value: "true"
+        - name: RCON_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "minecraft.fullname" . }}
+              key: rcon-password
+        {{- end }}
+
+        {{- if .Values.minecraftServer.query.enabled }}
+        - name: ENABLE_QUERY
+          value: "true"
+        - name: QUERY_PORT
+          value: {{ .Values.minecraftServer.query.port }}
+        {{- end }}
+
+        {{- range $key, $value := .Values.extraEnv }}
+        - name: {{ $key }}
+          value: {{ $value }}
+        {{- end }}
+
+        ports:
+        - name: minecraft
+          containerPort: 25565
+          protocol: TCP
+        {{- if .Values.minecraftServer.rcon.enabled }}
+        - name: rcon
+          containerPort: {{ .Values.minecraftServer.rcon.port }}
+          protocol: TCP
+        {{- end }}
+        volumeMounts:
+        - name: datadir
+          mountPath: /data
+      volumes:
+      - name: datadir
+      {{- if .Values.persistence.dataDir.enabled }}
+        persistentVolumeClaim:
+        {{- if .Values.persistence.dataDir.existingClaim }}
+          claimName: {{ .Values.persistence.dataDir.existingClaim }}
+        {{- else }}
+          claimName: {{ template "minecraft.fullname" . }}-datadir
+        {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+{{ end }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -41,18 +41,16 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         readinessProbe:
-          exec:
-            command: 
-{{ toYaml .Values.readinessProbe.command | indent 14 }}
+          tcpSocket:
+            port: 25565
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         livenessProbe:
-          exec:
-            command:
-{{ toYaml .Values.livenessProbe.command | indent 14 }}
+          tcpSocket:
+            port: 25565
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "minecraft.fullname" . }}
+  labels:
+    app: {{ template "minecraft.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+{{- if (or (eq .Values.minecraftServer.serviceType "ClusterIP") (empty .Values.minecraftServer.serviceType)) }}
+  type: ClusterIP
+{{- else if eq .Values.minecraftServer.serviceType "LoadBalancer" }}
+  type: {{ .Values.minecraftServer.serviceType }}
+  {{- if .Values.minecraftServer.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.minecraftServer.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.minecraftServer.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.minecraftServer.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.minecraftServer.serviceType }}
+{{- end }}
+  {{- if .Values.minecraftServer.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.minecraftServer.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+  - name: minecraft
+    port: 25565
+    targetPort: minecraft
+    protocol: TCP
+  selector:
+    app: {{ template "minecraft.fullname" . }}

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -1,0 +1,36 @@
+{{- if default "" .Values.minecraftServer.rcon.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "minecraft.fullname" . }}-rcon"
+  labels:
+    app: {{ template "minecraft.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+{{- if (or (eq .Values.minecraftServer.rcon.serviceType "ClusterIP") (empty .Values.minecraftServer.rcon.serviceType)) }}
+  type: ClusterIP
+{{- else if eq .Values.minecraftServer.rcon.serviceType "LoadBalancer" }}
+  type: {{ .Values.minecraftServer.rcon.serviceType }}
+  {{- if .Values.minecraftServer.rcon.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.minecraftServer.rcon.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.minecraftServer.rcon.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.minecraftServer.rcon.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.minecraftServer.rcon.serviceType }}
+{{- end }}
+  {{- if .Values.minecraftServer.rcon.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.minecraftServer.rcon.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+  - name: rcon
+    port: {{ .Values.minecraftServer.rcon.port }}
+    targetPort: rcon
+    protocol: TCP
+  selector:
+    app: {{ template "minecraft.fullname" . }}
+{{- end }}

--- a/charts/minecraft/templates/secrets.yaml
+++ b/charts/minecraft/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "minecraft.fullname" . }}
+  labels:
+    app: {{ template "minecraft.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  rcon-password: {{ default "" .Values.minecraftServer.rcon.password | b64enc | quote }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -1,0 +1,181 @@
+# ref: https://hub.docker.com/r/itzg/minecraft-server/
+image: itzg/minecraft-server
+imageTag: latest
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 512Mi
+    cpu: 500m
+
+# upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+securityContext:
+  # Security context settings
+  runAsUser: 1000
+  fsGroup: 2000
+# Most of these map to environment variables. See Minecraft for details:
+# https://hub.docker.com/r/itzg/minecraft-server/
+livenessProbe:
+  command:
+    - mc-monitor
+    - status
+    - localhost:25565
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  failureThreshold: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+readinessProbe:
+  command:
+    - mc-monitor
+    - status
+    - localhost:25565
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  failureThreshold: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+minecraftServer:
+  # This must be overridden, since we can't accept this for the user.
+  eula: "FALSE"
+  # One of: LATEST, SNAPSHOT, or a specific version (ie: "1.7.9").
+  version: "1.14.4"
+  # This can be one of "VANILLA", "FORGE", "SPIGOT", "BUKKIT", "PAPER", "FTB", "SPONGEVANILLA"
+  type: "VANILLA"
+  # If type is set to FORGE, this sets the version; this is ignored if forgeInstallerUrl is set
+  forgeVersion:
+  # If type is set to SPONGEVANILLA, this sets the version
+  spongeVersion:
+  # If type is set to FORGE, this sets the URL to download the Forge installer
+  forgeInstallerUrl:
+  # If type is set to BUKKIT, this sets the URL to download the Bukkit package
+  bukkitDownloadUrl:
+  # If type is set to SPIGOT, this sets the URL to download the Spigot package
+  spigotDownloadUrl:
+  # If type is set to PAPER, this sets the URL to download the PaperSpigot package
+  paperDownloadUrl:
+  # If type is set to FTB, this sets the server mod to run. You can also provide the URL to download the FTB package
+  ftbServerMod:
+  # Set to true if running Feed The Beast and get an error like "unable to launch forgemodloader"
+  ftbLegacyJavaFixer: false
+  # One of: peaceful, easy, normal, and hard
+  difficulty: easy
+  # A comma-separated list of player names to whitelist.
+  whitelist:
+  # A comma-separated list of player names who should be admins.
+  ops:
+  # A server icon URL for server listings. Auto-scaled and transcoded.
+  icon:
+  # Max connected players.
+  maxPlayers: 20
+  # This sets the maximum possible size in blocks, expressed as a radius, that the world border can obtain.
+  maxWorldSize: 10000
+  # Allows players to travel to the Nether.
+  allowNether: true
+  # Allows server to announce when a player gets an achievement.
+  announcePlayerAchievements: true
+  # Enables command blocks.
+  enableCommandBlock: true
+  # If true, players will always join in the default gameMode even if they were previously set to something else.
+  forcegameMode: false
+  # Defines whether structures (such as villages) will be generated.
+  generateStructures: true
+  # If set to true, players will be set to spectator mode if they die.
+  hardcore: false
+  # The maximum height in which building is allowed.
+  maxBuildHeight: 256
+  # The maximum number of milliseconds a single tick may take before the server watchdog stops the server with the message. -1 disables this entirely.
+  maxTickTime: 60000
+  # Determines if animals will be able to spawn.
+  spawnAnimals: true
+  # Determines if monsters will be spawned.
+  spawnMonsters: true
+  # Determines if villagers will be spawned.
+  spawnNPCs: true
+  # Max view distance (in chunks).
+  viewDistance: 10
+  # Define this if you want a specific map generation seed.
+  levelSeed:
+  # One of: creative, survival, adventure, spectator
+  gameMode: survival
+  # Message of the Day
+  motd: "Welcome to Minecraft on Kubernetes!"
+  # If true, enable player-vs-player damage.
+  pvp: false
+  # One of: DEFAULT, FLAT, LARGEBIOMES, AMPLIFIED, CUSTOMIZED
+  levelType: DEFAULT
+  # When levelType == FLAT or CUSTOMIZED, this can be used to further customize map generation.
+  # ref: https://hub.docker.com/r/itzg/minecraft-server/
+  generatorSettings:
+  worldSaveName: world
+  # If set, this URL will be downloaded at startup and used as a starting point
+  downloadWorldUrl:
+  # force re-download of server file
+  forceReDownload: false
+  # If set, the modpack at this URL will be downloaded at startup
+  downloadModpackUrl:
+  # If true, old versions of downloaded mods will be replaced with new ones from downloadModpackUrl
+  removeOldMods: false
+  # Check accounts against Minecraft account service.
+  onlineMode: true
+  # If you adjust this, you may need to adjust resources.requests above to match.
+  memory: 512M
+  # General JVM options to be passed to the Minecraft server invocation
+  jvmOpts: ""
+  # Options like -X that need to proceed general JVM options
+  jvmXXOpts: ""
+  serviceType: LoadBalancer
+  loadBalancerIP:
+  # loadBalancerSourceRanges: []
+  ## Set the externalTrafficPolicy in the Service to either Cluster or Local
+  # externalTrafficPolicy: Cluster
+
+  rcon:
+    # If you enable this, make SURE to change your password below.
+    enabled: false
+    port: 25575
+    password: "CHANGEME!"
+    serviceType: LoadBalancer
+    loadBalancerIP:
+    # loadBalancerSourceRanges: []
+    ## Set the externalTrafficPolicy in the Service to either Cluster or Local
+    # externalTrafficPolicy: Cluster
+
+
+  query:
+    # If you enable this, your server will be "published" to Gamespy
+    enabled: false
+    port: 25565
+
+## Additional minecraft container environment variables
+##
+extraEnv: {}
+
+persistence:
+  ## minecraft data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  dataDir:
+    # Set this to false if you don't care to persist state between restarts.
+    enabled: true
+    # existingClaim: nil
+    Size: 1Gi
+
+podAnnotations: {}
+
+deploymentAnnotations: {}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -26,13 +26,13 @@ securityContext:
 # Most of these map to environment variables. See Minecraft for details:
 # https://hub.docker.com/r/itzg/minecraft-server/
 livenessProbe:
-  initialDelaySeconds: 60
+  initialDelaySeconds: 30
   periodSeconds: 5
   failureThreshold: 10
   successThreshold: 1
   timeoutSeconds: 1
 readinessProbe:
-  initialDelaySeconds: 60
+  initialDelaySeconds: 30
   periodSeconds: 5
   failureThreshold: 10
   successThreshold: 1
@@ -164,7 +164,7 @@ persistence:
   # storageClass: "-"
   dataDir:
     # Set this to false if you don't care to persist state between restarts.
-    enabled: true
+    enabled: false
     # existingClaim: nil
     Size: 1Gi
 

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -26,13 +26,13 @@ securityContext:
 # Most of these map to environment variables. See Minecraft for details:
 # https://hub.docker.com/r/itzg/minecraft-server/
 livenessProbe:
-  initialDelaySeconds: 30
+  initialDelaySeconds: 60
   periodSeconds: 5
   failureThreshold: 10
   successThreshold: 1
   timeoutSeconds: 1
 readinessProbe:
-  initialDelaySeconds: 30
+  initialDelaySeconds: 60
   periodSeconds: 5
   failureThreshold: 10
   successThreshold: 1

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -126,7 +126,7 @@ minecraftServer:
   jvmOpts: ""
   # Options like -X that need to proceed general JVM options
   jvmXXOpts: ""
-  serviceType: LoadBalancer
+  serviceType: ClusterIP
   loadBalancerIP:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -26,20 +26,12 @@ securityContext:
 # Most of these map to environment variables. See Minecraft for details:
 # https://hub.docker.com/r/itzg/minecraft-server/
 livenessProbe:
-  command:
-    - mc-monitor
-    - status
-    - localhost:25565
   initialDelaySeconds: 30
   periodSeconds: 5
   failureThreshold: 10
   successThreshold: 1
   timeoutSeconds: 1
 readinessProbe:
-  command:
-    - mc-monitor
-    - status
-    - localhost:25565
   initialDelaySeconds: 30
   periodSeconds: 5
   failureThreshold: 10


### PR DESCRIPTION
Importing 'minecraft' chart from helm/charts to this repo.

* Bumped chart version to 2.0.0 so that it will appear greater than the version on helm/charts (this will help when using `helm search`)
* Naming the chart `minecraft` to maintain compatibility with existing chart, but we can give it a different name if that makes more sense.