### PR TITLE
[minecraft-bedrock] adding additional bedrock server options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ helm repo add itzg https://itzg.github.io/minecraft-server-charts/
 You can then run `helm search repo itzg` to see the charts.
 
 ## Charts
-
-* [minecraft](https://itzg.github.io/minecraft-server-charts)
+tt
+* [minecraft](https://github.com/itzg/minecraft-server-charts/tree/master/charts/minecraft)
+* [minecraft-bedrock](https://github.com/itzg/minecraft-server-charts/tree/master/charts/minecraft-bedrock)
 
 ```bash
 helm install --name your-release itzg/minecraft

--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 1.0.0
+version: 1.1.0
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -94,10 +94,6 @@ spec:
           value: {{ .Values.minecraftServer.texturepackRequired | quote }}
         - name: ONLINE_MODE
           value: {{ .Values.minecraftServer.onlineMode | quote }}
-        - name: VIEW_DISTANCE
-          value: {{ .Values.minecraftServer.viewDistance | quote }}
-        - name: TICK_DISTANCE
-          value: {{ .Values.minecraftServer.tickDistance | quote }}
         {{- range $key, $value := .Values.extraEnv }}
         - name: {{ $key }}
           value: {{ $value }}

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -94,10 +94,10 @@ spec:
           value: {{ .Values.minecraftServer.texturepackRequired | quote }}
         - name: ONLINE_MODE
           value: {{ .Values.minecraftServer.onlineMode | quote }}
-
-
-      
-
+        - name: VIEW_DISTANCE
+          value: {{ .Values.minecraftServer.viewDistance | quote }}
+        - name: TICK_DISTANCE
+          value: {{ .Values.minecraftServer.tickDistance | quote }}
         {{- range $key, $value := .Values.extraEnv }}
         - name: {{ $key }}
           value: {{ $value }}

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -62,8 +62,6 @@ minecraftServer:
   maxThreads: 8
   # Cheat like commands can be used.
   cheats: false
-  # Determines the type of map that is generated (DEFAULT, FLAT, LEGACY)
-  levelType: DEFAULT
   # type of kubernetes service to use
   serviceType: ClusterIP
   loadBalancerIP:

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -35,18 +35,18 @@ minecraftServer:
   # A comma-separated list of player names to whitelist.
   whitelist:
   # Max connected players.
-  maxPlayers: 20
+  maxPlayers: 10
   # The world is ticked this many chunks away from any player.
   tickDistance: 4
   # Max view distance (in chunks).
   viewDistance: 10
   # The "level-name" value is used as the world name and its folder name. The player may also copy their saved game folder here, and change the name to the same as that folder's to load it instead.
-  levelName: K8sLevel
+  levelName: level
   # Define this if you want a specific map generation seed.
   levelSeed:
   # One of: creative, survival, adventure, spectator
   gameMode: survival
-  # Permission level for new players joining for the first time.
+  # Permission level for new players joining for the first time (visitor, member, operator)
   defaultPermission: member
   # After a player has idled for this many minutes they get kicked.
   playerIdleTimeout: 30
@@ -54,12 +54,21 @@ minecraftServer:
   levelType: DEFAULT
   # Force clients to use texture packs in the current world
   texturepackRequired: false
-  # Used as the server name
-  serverName: K8sServer
+  # This is the server name shown in the in-game server list.
+  serverName: "Dedicated Server"
   # Check accounts against Minecraft account service.
   onlineMode: true
   # Maximum number of threads the server tries to use. If set to 0 or removed then it uses as many as possible.
   maxThreads: 8
+  # Cheat like commands can be used.
+  cheats: false
+  # Determines the type of map that is generated (DEFAULT, FLAT, LEGACY)
+  levelType: DEFAULT
+  # The maximum allowed view distance in number of chunks
+  viewDistance: 10
+  # The world is ticked this many chunks away from any player
+  tickDistance: 4
+  # type of kubernetes service to use
   serviceType: ClusterIP
   loadBalancerIP:
   # loadBalancerSourceRanges: []

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -64,10 +64,6 @@ minecraftServer:
   cheats: false
   # Determines the type of map that is generated (DEFAULT, FLAT, LEGACY)
   levelType: DEFAULT
-  # The maximum allowed view distance in number of chunks
-  viewDistance: 10
-  # The world is ticked this many chunks away from any player
-  tickDistance: 4
   # type of kubernetes service to use
   serviceType: ClusterIP
   loadBalancerIP:


### PR DESCRIPTION
* Update repo README to show new chart
* add missing bedrock server options
* using default server values (for things like level name, world name, max players) sourced from [here](https://minecraft.gamepedia.com/Server.properties#Bedrock_Edition_3)