### PR TITLE
[minecraft] - Remove deprecated storageclass annotation

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.0.2
+version: 2.0.3
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/datadir-pvc.yaml
+++ b/charts/minecraft/templates/datadir-pvc.yaml
@@ -9,11 +9,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Using annotations for storageclass names was [deprecated in kubernetes
1.6](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/#using-dynamic-provisioning) and causes issues with some backup/restore scenarios when still present.

This should still operate properly without the old-style annotation approach.