### PR TITLE
[minecraft-bedrock] - Remove deprecated storageclass annotation

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: minecraft-bedrock
 version: 1.1.1
-appVersion: 1.14.4
+appVersion: 1.16.1
 home: https://minecraft.net/
 description: Minecraft server
 keywords:

--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: minecraft-bedrock
 version: 1.1.1
-appVersion: 1.16.1
+appVersion: 1.16
 home: https://minecraft.net/
 description: Minecraft server
 keywords:

--- a/charts/minecraft-bedrock/templates/datadir-pvc.yaml
+++ b/charts/minecraft-bedrock/templates/datadir-pvc.yaml
@@ -9,11 +9,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -29,7 +29,7 @@ minecraftServer:
   # This must be overridden, since we can't accept this for the user.
   eula: "FALSE"
   # One of: LATEST, SNAPSHOT, or a specific version (ie: "1.7.9").
-  version: "1.14.4"
+  version: "1.16.1.02"
   # One of: peaceful, easy, normal, and hard
   difficulty: easy
   # A comma-separated list of player names to whitelist.

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -29,7 +29,7 @@ minecraftServer:
   # This must be overridden, since we can't accept this for the user.
   eula: "FALSE"
   # One of: LATEST, SNAPSHOT, or a specific version (ie: "1.7.9").
-  version: "1.16.1.02"
+  version: "LATEST"
   # One of: peaceful, easy, normal, and hard
   difficulty: easy
   # A comma-separated list of player names to whitelist.


### PR DESCRIPTION
Using annotations for storageclass names was [deprecated in kubernetes
1.6](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/#using-dynamic-provisioning) and causes issues with some backup/restore scenarios when still present.

This should still operate properly without the old-style annotation approach.

Also needed to bump the server version to '1.16.1.02' in order for it to download properly from upstream