### PR TITLE
Add externalIPs support for the minecraft service

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.0.6
+version: 2.0.7
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -32,3 +32,11 @@ spec:
     protocol: TCP
   selector:
     app: {{ template "minecraft.fullname" . }}
+  {{- if .Values.minecraftServer.externalIPs }}
+  externalIPs:
+    {{- with .Values.minecraftServer.externalIPs }}
+      {{- range . }}
+        - {{ . | quote }}
+      {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -132,6 +132,7 @@ minecraftServer:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local
   # externalTrafficPolicy: Cluster
+  externalIPs: 
 
   rcon:
     # If you enable this, make SURE to change your password below.

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -132,7 +132,7 @@ minecraftServer:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local
   # externalTrafficPolicy: Cluster
-  externalIPs: 
+  externalIPs:
 
   rcon:
     # If you enable this, make SURE to change your password below.


### PR DESCRIPTION
This change will allow users to specify an minecraftServer.externalIPs to allow access to the minecraft service instead of using a load balancer. 

Example:
```Bash
helm upgrade minecraft ./charts/minecraft -n default --set minecraftServer.eula=true --set minecraftServer.externalIPs='{192.168.1.25}'
```