### PR TITLE
Fix capitalization of FORCE_GAMEMODE environment variable

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.0.7
+version: 2.0.8
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
           value: {{ .Values.minecraftServer.announcePlayerAchievements | quote }}
         - name: ENABLE_COMMAND_BLOCK
           value: {{ .Values.minecraftServer.enableCommandBlock | quote }}
-        - name: FORCE_gameMode
+        - name: FORCE_GAMEMODE
           value: {{ .Values.minecraftServer.forcegameMode | quote }}
         {{- if .Values.minecraftServer.forceReDownload }}
         - name: FORCE_REDOWNLOAD


### PR DESCRIPTION
The previous capitalization caused `forcegameMode`'s value to be silently ignored