### PR TITLE
Add ability to specify node port for minecraft service

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 1.1.4
+version: 1.1.5
 appVersion: 1.16
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/minecraft-svc.yaml
+++ b/charts/minecraft-bedrock/templates/minecraft-svc.yaml
@@ -29,6 +29,9 @@ spec:
   - name: minecraft
     port: 19132
     targetPort: minecraft
+    {{- if .Values.minecraftServer.nodePort }}
+    nodePort: {{ .Values.minecraftServer.nodePort }}
+    {{- end }}
     protocol: UDP
   selector:
     app: {{ template "minecraft.fullname" . }}

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -83,6 +83,8 @@ minecraftServer:
   cheats: false
   # type of kubernetes service to use
   serviceType: ClusterIP
+  ## Set the port used if the serviceType is NodePort
+  # nodePort:
   loadBalancerIP:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.0.8
+version: 2.0.9
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -29,6 +29,9 @@ spec:
   - name: minecraft
     port: 25565
     targetPort: minecraft
+    {{- if .Values.minecraftServer.nodePort }}
+    nodePort: {{ .Values.minecraftServer.nodePort }}
+    {{- end }}
     protocol: TCP
   selector:
     app: {{ template "minecraft.fullname" . }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -128,6 +128,8 @@ minecraftServer:
   jvmXXOpts: ""
   serviceAnnotations: {}
   serviceType: ClusterIP
+  ## Set the port used if the serviceType is NodePort
+  # nodePort:
   loadBalancerIP:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local


### PR DESCRIPTION
This adds the ability to set the nodePort for the service that way we can get a predictable port when deploying this via nodeport. I added some documentation to the values files, but am not sure if this should be documented elsewhere