### PR TITLE
adding imagePullSecrets support

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 1.1.5
+version: 1.1.6
 appVersion: 1.16
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret }}
+      {{- end }}
       containers:
       - name: {{ template "minecraft.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -1,6 +1,7 @@
 # ref: https://hub.docker.com/r/itzg/minecraft-server/
 image: itzg/minecraft-bedrock-server
 imageTag: latest
+imagePullSecret: ""
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.0.10
+version: 2.0.11
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret }}
+      {{- end }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -1,6 +1,7 @@
 # ref: https://hub.docker.com/r/itzg/minecraft-server/
 image: itzg/minecraft-server
 imageTag: latest
+imagePullSecret: ""
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
With the advent of Docker's anonymous image pull limitations, some users have been implementing docker authenticated pulls in their kubernetes clusters.

In order to support an authenticated pull, kubernetes provides the `imagePullSecrets` directive to authenticate to either a private registry or authenticated to Docker Hub. This PR aims to allow users the flexibility on specifying their own image pull secret.

Please let me know how I can help assist in getting this merged!