### PR TITLE
Adding startup probe

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.0.12
+version: 2.0.13
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -44,6 +44,13 @@ spec:
         imagePullPolicy: Always
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.startupProbe.enabled }}
+        startupProbe:
+          tcpSocket:
+            port: 25565
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+        {{- end }}
         readinessProbe:
           tcpSocket:
             port: 25565

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -38,6 +38,11 @@ readinessProbe:
   failureThreshold: 10
   successThreshold: 1
   timeoutSeconds: 1
+startupProbe:
+  enabled: false
+  failureThreshold: 30
+  periodSeconds: 10
+
 minecraftServer:
   # This must be overridden, since we can't accept this for the user.
   eula: "FALSE"


### PR DESCRIPTION
Adding a startup probe to the chart.

I found that the initial downloads can take a long time. I had a startup world that was about 10 gigs of data, that took time to install as did paper. Adding this startup probe allowed the pod to complete the work before being killed and allows liveness checks to still be peppy to catch crashes.