### PR TITLE
adding dynmap support

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.0.14
+version: 2.1.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.0.13
+version: 2.0.14
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -205,6 +205,11 @@ spec:
           containerPort: {{ .Values.minecraftServer.rcon.port }}
           protocol: TCP
         {{- end }}
+        {{- if .Values.minecraftServer.dynmap.service.enabled }}
+        - name: dynmap
+          containerPort: {{ .Values.minecraftServer.dynmap.containerPort }}
+          protocol: TCP
+        {{- end }}
         volumeMounts:
         - name: datadir
           mountPath: /data

--- a/charts/minecraft/templates/dynmap-ing.yaml
+++ b/charts/minecraft/templates/dynmap-ing.yaml
@@ -1,0 +1,42 @@
+{{- if default "" .Values.minecraftServer.dynmap.ingress.enabled }}
+{{- $minecraftFullname := include "minecraft.fullname" . }}
+{{- $serviceName := printf "%s-dynmap" $minecraftFullname }}
+{{- $servicePort := .Values.minecraftServer.dynmap.service.port }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ $minecraftFullname }}-dynmap"
+  {{- if .Values.minecraftServer.dynmap.ingress.annotations }}
+  annotations:
+    {{- toYaml .Values.minecraftServer.dynmap.ingress.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    app: "{{ $minecraftFullname }}-dynmap"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+{{- if .Values.minecraftServer.dynmap.ingress.tls }}
+  tls:
+  {{- range .Values.minecraftServer.dynmap.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.minecraftServer.dynmap.ingress.hosts }}
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ .path | default "/" }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/charts/minecraft/templates/dynmap-svc.yaml
+++ b/charts/minecraft/templates/dynmap-svc.yaml
@@ -1,0 +1,38 @@
+{{- if default "" .Values.minecraftServer.dynmap.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "minecraft.fullname" . }}-dynmap"
+  annotations:
+    {{ toYaml .Values.minecraftServer.dynmap.service.annotations | indent 4 }}
+  labels:
+    app: {{ template "minecraft.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+{{- if (or (eq .Values.minecraftServer.dynmap.service.type "ClusterIP") (empty .Values.minecraftServer.dynmap.service.type)) }}
+  type: ClusterIP
+{{- else if eq .Values.minecraftServer.dynmap.service.type "LoadBalancer" }}
+  type: {{ .Values.minecraftServer.dynmap.service.type }}
+  {{- if .Values.minecraftServer.dynmap.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.minecraftServer.dynmap.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.minecraftServer.dynmap.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.minecraftServer.dynmap.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.minecraftServer.dynmap.service.type }}
+{{- end }}
+  {{- if .Values.minecraftServer.dynmap.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.minecraftServer.dynmap.service.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+  - name: dynmap
+    port: {{ .Values.minecraftServer.dynmap.service.port }}
+    targetPort: dynmap
+    protocol: TCP
+  selector:
+    app: {{ template "minecraft.fullname" . }}
+{{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -153,6 +153,33 @@ minecraftServer:
     ## Set the externalTrafficPolicy in the Service to either Cluster or Local
     # externalTrafficPolicy: Cluster
 
+  dynmap:
+    # Enabling any of these options will not install dynmap to your server, but
+    # opens up a service and possibly an ingress to access dynmap on your server.
+    # To install dynmap, see downloadModpackUrl
+
+    containerPort: 8123
+    service:
+      # Enable a service for dynmap
+      enabled: false
+      annotations: {}
+      type: ClusterIP
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+      # externalTrafficPolicy: Cluster
+      port: 8123
+    ingress:
+      enabled: false
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      hosts:
+        - name: dynmap.local
+          path: /
+      tls: []
+      #  - secretName: dynmap-tls
+      #    hosts:
+      #      - dynmap.local
 
   query:
     # If you enable this, your server will be "published" to Gamespy


### PR DESCRIPTION
Added dynmap support as discussed in #37. This is more tailored at dynmap and allows easily opening a port or adding an ingress for dynmap, but will not install the dynmap plugin for you. 