### PR TITLE
Added serviceAnnotations to minecraft-svc manifests

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 1.1.7
+version: 1.1.8
 appVersion: 1.16
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/minecraft-svc.yaml
+++ b/charts/minecraft-bedrock/templates/minecraft-svc.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    {{ toYaml .Values.serviceAnnotations | indent 4 }}
 spec:
 {{- if (or (eq .Values.minecraftServer.serviceType "ClusterIP") (empty .Values.minecraftServer.serviceType)) }}
   type: ClusterIP

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -139,3 +139,5 @@ persistence:
 podAnnotations: {}
 
 deploymentAnnotations: {}
+
+serviceAnnotations: {}

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.1.1
+version: 2.1.2
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    {{ toYaml .Values.serviceAnnotations | indent 4 }}
 spec:
 {{- if (or (eq .Values.minecraftServer.serviceType "ClusterIP") (empty .Values.minecraftServer.serviceType)) }}
   type: ClusterIP

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: "{{ template "minecraft.fullname" . }}-rcon"
   annotations:
     {{ toYaml .Values.minecraftServer.serviceAnnotations | indent 4 }}
+    {{ toYaml .Values.serviceAnnotations | indent 4 }}
   labels:
     app: {{ template "minecraft.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -233,3 +233,5 @@ persistence:
 podAnnotations: {}
 
 deploymentAnnotations: {}
+
+serviceAnnotations: {}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -157,6 +157,7 @@ minecraftServer:
   jvmOpts: ""
   # Options like -X that need to proceed general JVM options
   jvmXXOpts: ""
+  # DEPRECATED use top-level serviceAnnotations
   serviceAnnotations: {}
   serviceType: ClusterIP
   ## Set the port used if the serviceType is NodePort


### PR DESCRIPTION
The java edition chart [seems to have the `serviceAnnotations` misplaced](https://github.com/itzg/minecraft-server-charts/blob/4256283a24302ac70d9edd8f7a80b6ea17ad9160/charts/minecraft/values.yaml#L160) compared to the pod and deployment annotations. So, in this PR I'm proposing that `serviceAnnotations` be a top level value.

Went ahead and made the same change for bedrock since it was lacking that value all together.

Fixes #41 