### PR TITLE
Corrected rendering of rcon service annotations

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.1.2
+version: 2.1.3
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    {{ toYaml .Values.serviceAnnotations | indent 4 }}
+{{ toYaml .Values.serviceAnnotations | indent 4 }}
 spec:
 {{- if (or (eq .Values.minecraftServer.serviceType "ClusterIP") (empty .Values.minecraftServer.serviceType)) }}
   type: ClusterIP

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -4,8 +4,7 @@ kind: Service
 metadata:
   name: "{{ template "minecraft.fullname" . }}-rcon"
   annotations:
-    {{ toYaml .Values.minecraftServer.serviceAnnotations | indent 4 }}
-    {{ toYaml .Values.serviceAnnotations | indent 4 }}
+{{ toYaml .Values.rconServiceAnnotations | indent 4 }}
   labels:
     app: {{ template "minecraft.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -157,7 +157,7 @@ minecraftServer:
   jvmOpts: ""
   # Options like -X that need to proceed general JVM options
   jvmXXOpts: ""
-  # DEPRECATED use top-level serviceAnnotations
+  # DEPRECATED: use top-level rconServiceAnnotations instead
   serviceAnnotations: {}
   serviceType: ClusterIP
   ## Set the port used if the serviceType is NodePort
@@ -236,3 +236,5 @@ podAnnotations: {}
 deploymentAnnotations: {}
 
 serviceAnnotations: {}
+
+rconServiceAnnotations: {}


### PR DESCRIPTION
In addition to introducing a specific `rconServiceAnnotations` I fixed the yaml indentation for the service annotations. They were all adding a redundant indentation on the first yaml entry.

I'm wondering if I should have used a template merge operator to combine the now-deprecated values into the new one.

Fixes #45 
Related to #43