### PR TITLE
fix(minecraft)!: replace references to dynmap with extraPort

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 2.1.5
+version: 3.0.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -209,9 +209,9 @@ spec:
           containerPort: {{ .Values.minecraftServer.rcon.port }}
           protocol: TCP
         {{- end }}
-        {{- if .Values.minecraftServer.dynmap.service.enabled }}
-        - name: dynmap
-          containerPort: {{ .Values.minecraftServer.dynmap.containerPort }}
+        {{- if .Values.minecraftServer.extraPort.service.enabled }}
+        - name: extraPort
+          containerPort: {{ .Values.minecraftServer.extraPort.containerPort }}
           protocol: TCP
         {{- end }}
         volumeMounts:

--- a/charts/minecraft/templates/dynmap-ing.yaml
+++ b/charts/minecraft/templates/dynmap-ing.yaml
@@ -1,24 +1,24 @@
-{{- if default "" .Values.minecraftServer.dynmap.ingress.enabled }}
+{{- if default "" .Values.minecraftServer.extraPort.ingress.enabled }}
 {{- $minecraftFullname := include "minecraft.fullname" . }}
-{{- $serviceName := printf "%s-dynmap" $minecraftFullname }}
-{{- $servicePort := .Values.minecraftServer.dynmap.service.port }}
+{{- $serviceName := printf "%s-extraPort" $minecraftFullname }}
+{{- $servicePort := .Values.minecraftServer.extraPort.service.port }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: "{{ $minecraftFullname }}-dynmap"
-  {{- if .Values.minecraftServer.dynmap.ingress.annotations }}
+  name: "{{ $minecraftFullname }}-extraPort"
+  {{- if .Values.minecraftServer.extraPort.ingress.annotations }}
   annotations:
-    {{- toYaml .Values.minecraftServer.dynmap.ingress.annotations | nindent 4 }}
+    {{- toYaml .Values.minecraftServer.extraPort.ingress.annotations | nindent 4 }}
   {{- end }}
   labels:
-    app: "{{ $minecraftFullname }}-dynmap"
+    app: "{{ $minecraftFullname }}-extraPort"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-{{- if .Values.minecraftServer.dynmap.ingress.tls }}
+{{- if .Values.minecraftServer.extraPort.ingress.tls }}
   tls:
-  {{- range .Values.minecraftServer.dynmap.ingress.tls }}
+  {{- range .Values.minecraftServer.extraPort.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}
@@ -27,7 +27,7 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.minecraftServer.dynmap.ingress.hosts }}
+  {{- range .Values.minecraftServer.extraPort.ingress.hosts }}
   - host: {{ .name }}
     http:
       paths:

--- a/charts/minecraft/templates/dynmap-svc.yaml
+++ b/charts/minecraft/templates/dynmap-svc.yaml
@@ -1,37 +1,37 @@
-{{- if default "" .Values.minecraftServer.dynmap.service.enabled }}
+{{- if default "" .Values.minecraftServer.extraPort.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "minecraft.fullname" . }}-dynmap"
+  name: "{{ template "minecraft.fullname" . }}-extraPort"
   annotations:
-    {{ toYaml .Values.minecraftServer.dynmap.service.annotations | indent 4 }}
+    {{ toYaml .Values.minecraftServer.extraPort.service.annotations | indent 4 }}
   labels:
     app: {{ template "minecraft.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-{{- if (or (eq .Values.minecraftServer.dynmap.service.type "ClusterIP") (empty .Values.minecraftServer.dynmap.service.type)) }}
+{{- if (or (eq .Values.minecraftServer.extraPort.service.type "ClusterIP") (empty .Values.minecraftServer.extraPort.service.type)) }}
   type: ClusterIP
-{{- else if eq .Values.minecraftServer.dynmap.service.type "LoadBalancer" }}
-  type: {{ .Values.minecraftServer.dynmap.service.type }}
-  {{- if .Values.minecraftServer.dynmap.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.minecraftServer.dynmap.service.loadBalancerIP }}
+{{- else if eq .Values.minecraftServer.extraPort.service.type "LoadBalancer" }}
+  type: {{ .Values.minecraftServer.extraPort.service.type }}
+  {{- if .Values.minecraftServer.extraPort.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.minecraftServer.extraPort.service.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.minecraftServer.dynmap.service.loadBalancerSourceRanges }}
+  {{- if .Values.minecraftServer.extraPort.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml .Values.minecraftServer.dynmap.service.loadBalancerSourceRanges | indent 4 }}
+{{ toYaml .Values.minecraftServer.extraPort.service.loadBalancerSourceRanges | indent 4 }}
   {{- end -}}
 {{- else }}
-  type: {{ .Values.minecraftServer.dynmap.service.type }}
+  type: {{ .Values.minecraftServer.extraPort.service.type }}
 {{- end }}
-  {{- if .Values.minecraftServer.dynmap.service.externalTrafficPolicy }}
-  externalTrafficPolicy: {{ .Values.minecraftServer.dynmap.service.externalTrafficPolicy }}
+  {{- if .Values.minecraftServer.extraPort.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.minecraftServer.extraPort.service.externalTrafficPolicy }}
   {{- end }}
   ports:
-  - name: dynmap
-    port: {{ .Values.minecraftServer.dynmap.service.port }}
-    targetPort: dynmap
+  - name: extraPort
+    port: {{ .Values.minecraftServer.extraPort.service.port }}
+    targetPort: extraPort
     protocol: TCP
   selector:
     app: {{ template "minecraft.fullname" . }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -179,14 +179,11 @@ minecraftServer:
     ## Set the externalTrafficPolicy in the Service to either Cluster or Local
     # externalTrafficPolicy: Cluster
 
-  dynmap:
-    # Enabling any of these options will not install dynmap to your server, but
-    # opens up a service and possibly an ingress to access dynmap on your server.
-    # To install dynmap, see downloadModpackUrl
-
+  extraPort:
+    # These options allow you to expose another port from the Minecraft server, plugins such
+    # as dynmap (8123) and bluemap (8100) will require this for access to their web interfaces
     containerPort: 8123
     service:
-      # Enable a service for dynmap
       enabled: false
       annotations: {}
       type: ClusterIP
@@ -196,16 +193,17 @@ minecraftServer:
       port: 8123
     ingress:
       enabled: false
-      annotations: {}
+      annotations:
+        {}
         # kubernetes.io/ingress.class: nginx
         # kubernetes.io/tls-acme: "true"
       hosts:
-        - name: dynmap.local
+        - name: map.local
           path: /
       tls: []
-      #  - secretName: dynmap-tls
+      #  - secretName: map-tls
       #    hosts:
-      #      - dynmap.local
+      #      - map.local
 
   query:
     # If you enable this, your server will be "published" to Gamespy


### PR DESCRIPTION
Fixes #53 

BREAKING CHANGE: `dynmap` refs in values are replaced with `extraPort`