### PR TITLE
minecraft-proxy: Correct rendering with toYaml in ConfigMap

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.0.1
+version: 2.0.2
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/configmap.yaml
+++ b/charts/minecraft-proxy/templates/configmap.yaml
@@ -9,5 +9,5 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  config.yml: {{ toYaml .Values.minecraftProxy.config | indent 4 }}
+  config.yml: {{ toYaml .Values.minecraftProxy.config | indent 2 }}
 {{- end }}

--- a/charts/minecraft-proxy/templates/configmap.yaml
+++ b/charts/minecraft-proxy/templates/configmap.yaml
@@ -9,6 +9,5 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  config.yml: |
-{{ toYaml .Values.minecraftProxy.config | indent 4 }}
+  config.yml: {{ toYaml .Values.minecraftProxy.config | indent 4 }}
 {{- end }}


### PR DESCRIPTION
This PR corrects an issue caused by a duplicate block scaler token in the ConfigMap created when the `minecraftProxy.config` value is supplied.

The current ConfigMap template defines the `config.yml` file as follows:
```
data:
  config.yml: |
{{ toYaml .Values.minecraftProxy.config | indent 4 }}
```

Using the following `custom-values.yml` as an example:
```
minecraftProxy:
  config: |
    ---
    online_mode: true
    servers:
      lobby:
        motd: 'Testing...'
        address: minecraft-minecraft:25565
        restricted: false
```

and after rendering the template, the resulting `config.yml` file is not valid yaml:
```
keith.king at jump in ~/.../charts/minecraft-proxy on (HEAD detached at minecraft-proxy-2.0.1)*
$ helm template -f values.yaml -f custom-values.yml bungeecord .
<truncated for brevity>
---
# Source: minecraft-proxy/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: bungeecord-minecraft-proxy-config
  labels:
    app: bungeecord-minecraft-proxy
    chart: "minecraft-proxy-2.0.1"
    release: "bungeecord"
    heritage: "Helm"
data:
  config.yml: |
    |
      ---
      online_mode: true
      servers:
        lobby:
          motd: 'Testing...'
          address: minecraft-minecraft:25565
          restricted: false
<truncated for brevity>
```
Note the extra block scaler appearing on the newline, this results in `config.yml` being rendered containing the block scaler, and subsequently bungeecord fails to startup since it cannot successfully parse the config file.

After the change introduced in this PR, the template is rendered to valid yaml:
```
keith.king at jump in ~/.../charts/minecraft-proxy on fix-config*
$ helm template -f values.yaml -f custom-values.yml bungeecord .
<truncated for brevity>
---
# Source: minecraft-proxy/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: bungeecord-minecraft-proxy-config
  labels:
    app: bungeecord-minecraft-proxy
    chart: "minecraft-proxy-2.0.1"
    release: "bungeecord"
    heritage: "Helm"
data:
  config.yml:   |
    ---
    online_mode: true
    servers:
      lobby:
        motd: 'Testing...'
        address: minecraft-minecraft:25565
        restricted: false
<truncated for brevity>
```