### PR TITLE
Support usage of an existing secret for rcon

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.1.3
+version: 3.1.4
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -182,8 +182,8 @@ spec:
         - name: RCON_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "minecraft.fullname" . }}
-              key: rcon-password
+              name: {{ .Values.minecraftServer.rcon.existingSecret | default (include "minecraft.fullname" .) }}
+              key: {{ .Values.minecraftServer.rcon.secretKey | default "rcon-password" }}
         {{- else }}
         - name: ENABLE_RCON
           value: "false"

--- a/charts/minecraft/templates/secrets.yaml
+++ b/charts/minecraft/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.minecraftServer.rcon.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
 type: Opaque
 data:
   rcon-password: {{ default "" .Values.minecraftServer.rcon.password | b64enc | quote }}
+{{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -173,6 +173,8 @@ minecraftServer:
     enabled: false
     port: 25575
     password: "CHANGEME!"
+    existingSecret:
+    secretKey: rcon-password
     serviceType: LoadBalancer
     loadBalancerIP:
     # loadBalancerSourceRanges: []


### PR DESCRIPTION
Inspired by the [grafana chart](https://github.com/grafana/helm-charts/blob/main/charts/grafana).
The ability to use an existing secret for the rcon password allows users to add the `values.yaml` to version control without exposing the password.
