### PR TITLE
Allow changing the service port

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.1.4
+version: 3.1.5
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/NOTES.txt
+++ b/charts/minecraft/templates/NOTES.txt
@@ -34,7 +34,7 @@ You can watch for EXTERNAL-IP to populate by running:
     --namespace {{ .Release.Namespace }} \
     -l "component={{ template "minecraft.fullname" . }}" \
     -o jsonpath="{.items[0].metadata.name}")
-  kubectl port-forward $POD_NAME 25565:25565
+  kubectl port-forward $POD_NAME 25565:{{ .Values.minecraftServer.servicePort | default 25565 }}
   echo "Point your Minecraft client at 127.0.0.1:22565"
 
 {{- end }}

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -29,7 +29,7 @@ spec:
   {{- end }}
   ports:
   - name: minecraft
-    port: 25565
+    port: {{ .Values.minecraftServer.servicePort | default 25565 }}
     targetPort: minecraft
     {{- if .Values.minecraftServer.nodePort }}
     nodePort: {{ .Values.minecraftServer.nodePort }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -162,6 +162,8 @@ minecraftServer:
   serviceType: ClusterIP
   ## Set the port used if the serviceType is NodePort
   # nodePort:
+  ## Set the external port of the service, usefull when using the LoadBalancer service type
+  # servicePort:
   loadBalancerIP:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -162,8 +162,8 @@ minecraftServer:
   serviceType: ClusterIP
   ## Set the port used if the serviceType is NodePort
   # nodePort:
-  ## Set the external port of the service, usefull when using the LoadBalancer service type
-  # servicePort:
+  # Set the external port of the service, usefull when using the LoadBalancer service type
+  servicePort: 25565
   loadBalancerIP:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local


### PR DESCRIPTION
Changing the external service port is useful when using the type `LoadBalancer` with `k3s` (maybe cloud clusters as well). 
Previously it was not possible to run multiple instances with type `LoadBalancer`, as the it does not expose the `nodePort`, but the `port` of a service.
