### PR TITLE
Add support for CURSEFORGE + CF_SERVER_MOD

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.1.5
+version: 3.1.6
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -98,6 +98,11 @@ spec:
           value: {{ .Values.minecraftServer.ftbServerMod | quote }}
         - name: FTB_LEGACYJAVAFIXER
           value: {{ default false .Values.minecraftServer.ftbLegacyJavaFixer | quote }}
+        {{- else if eq .Values.minecraftServer.type "CURSEFORGE" }}
+        - name: CF_SERVER_MOD
+          value: {{ .Values.minecraftServer.cfServerMod | quote }}
+        - name: FTB_LEGACYJAVAFIXER
+          value: {{ default false .Values.minecraftServer.ftbLegacyJavaFixer | quote }}
         {{- end }}
         - name: VERSION
           value: {{ .Values.minecraftServer.version | quote }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -73,7 +73,7 @@ minecraftServer:
   eula: "FALSE"
   # One of: LATEST, SNAPSHOT, or a specific version (ie: "1.7.9").
   version: "LATEST"
-  # This can be one of "VANILLA", "FORGE", "SPIGOT", "BUKKIT", "PAPER", "FTBA", "SPONGEVANILLA"
+  # This can be one of "VANILLA", "FORGE", "SPIGOT", "BUKKIT", "PAPER", "FTBA", "SPONGEVANILLA", "CURSEFORGE"
   type: "VANILLA"
   # If type is set to FORGE, this sets the version; this is ignored if forgeInstallerUrl is set
   forgeVersion:
@@ -89,6 +89,8 @@ minecraftServer:
   paperDownloadUrl:
   # If type is set to FTB, this sets the server mod to run. You can also provide the URL to download the FTB package
   ftbServerMod:
+  # If type is set to CURSEFORGE, this sets the server mod to run. Can also provide url to curseforge package.
+  cfServerMod:
   # Set to true if running Feed The Beast and get an error like "unable to launch forgemodloader"
   ftbLegacyJavaFixer: false
   # One of: peaceful, easy, normal, and hard


### PR DESCRIPTION
Simple PR to add support for the CURSEFORGE type via CF_SERVER_MOD.

In the interim, can work around this by using extraEnv to set CF_SERVER_MOD directly.