### PR TITLE
add nodePort to rcon service

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.1.6
+version: 3.1.7
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.1.7
+version: 3.1.8
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -66,7 +66,7 @@ you can change the values.yaml to enable persistence under the sub-sections unde
 
 ## Backups
 
-You can backup the state of your minecraft server to your local machine via the `kubectl cp` command.  
+You can backup the state of your minecraft server to your local machine via the `kubectl cp` command.
 
 ```shell
 NAMESPACE=default
@@ -76,3 +76,11 @@ kubectl exec --namespace ${NAMESPACE} ${POD_ID} rcon-cli save-all
 kubectl cp ${NAMESPACE}/${POD_ID}:/data .
 kubectl exec --namespace ${NAMESPACE} ${POD_ID} rcon-cli save-on
 ```
+
+## Tutorials
+
+For a quickstart guide to setting up a Kubernetes cluster and deploying
+Minecraft servers using this Helm Chart see:
+
+[gilesknap/k3s-minecraft](https://github.com/gilesknap/k3s-minecraft)
+

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -31,6 +31,9 @@ spec:
   ports:
   - name: rcon
     port: {{ .Values.minecraftServer.rcon.port }}
+    {{- if .Values.minecraftServer.rcon.nodePort }}
+    nodePort: {{ .Values.minecraftServer.rcon.nodePort }}
+    {{- end }}
     targetPort: rcon
     protocol: TCP
   selector:

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -180,6 +180,8 @@ minecraftServer:
     existingSecret:
     secretKey: rcon-password
     serviceType: LoadBalancer
+    ## Set the external port if the rcon serviceType is NodePort
+    # nodePort: 
     loadBalancerIP:
     # loadBalancerSourceRanges: []
     ## Set the externalTrafficPolicy in the Service to either Cluster or Local


### PR DESCRIPTION
This gives the rcon service definition the same options as the minecraft service.

(I need external rcon because I'm experimenting with world building using a python rcon client https://github.com/conqp/mcwb) 