### PR TITLE
fix(minecraft): expose protocol config for extra ports

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.1.8
+version: 3.2.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -218,7 +218,7 @@ spec:
         {{- if .service.enabled }}
         - name: {{ .name }}
           containerPort: {{ .containerPort }}
-          protocol: TCP
+          protocol: {{ .protocol }}
         {{- end }}
         {{- end }}
         volumeMounts:

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -218,7 +218,11 @@ spec:
         {{- if .service.enabled }}
         - name: {{ .name }}
           containerPort: {{ .containerPort }}
+          {{- if .protocol }}
           protocol: {{ .protocol }}
+          {{- else }}
+          protocol: TCP
+          {{- end }}
         {{- end }}
         {{- end }}
         volumeMounts:

--- a/charts/minecraft/templates/extraports-svc.yaml
+++ b/charts/minecraft/templates/extraports-svc.yaml
@@ -35,7 +35,7 @@ spec:
   - name: {{ .name }}
     port: {{ .service.port }}
     targetPort: {{ .name }}
-    protocol: TCP
+    protocol: {{ .protocol }}
   selector:
     app: {{ $minecraftFullname }}
 {{- end }}

--- a/charts/minecraft/templates/extraports-svc.yaml
+++ b/charts/minecraft/templates/extraports-svc.yaml
@@ -35,7 +35,11 @@ spec:
   - name: {{ .name }}
     port: {{ .service.port }}
     targetPort: {{ .name }}
+    {{- if .protocol }}
     protocol: {{ .protocol }}
+    {{- else }}
+    protocol: TCP
+    {{- end }}
   selector:
     app: {{ $minecraftFullname }}
 {{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -193,6 +193,7 @@ minecraftServer:
     #
     # - name: map
     #   containerPort: 8123
+    #   protocol: TCP
     #   service:
     #     enabled: false
     #     annotations: {}


### PR DESCRIPTION
We've got a service for voice chat in-game which requires UDP, I realized this option was not exposed, so here it is.