### PR TITLE
feat(minecraft-proxy): add extra port capability

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.0.3
+version: 2.1.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -132,7 +132,11 @@ spec:
         {{- if .service.enabled }}
         - name: {{ .name }}
           containerPort: {{ .containerPort }}
+          {{- if .protocol }}
           protocol: {{ .protocol }}
+          {{- else }}
+          protocol: TCP
+          {{- end }}
         {{- end }}
         {{- end }}
         volumeMounts:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -128,6 +128,13 @@ spec:
           containerPort: 25575
           protocol: TCP
         {{- end }}
+        {{- range .Values.minecraftProxy.extraPorts }}
+        {{- if .service.enabled }}
+        - name: {{ .name }}
+          containerPort: {{ .containerPort }}
+          protocol: {{ .protocol }}
+        {{- end }}
+        {{- end }}
         volumeMounts:
         - name: datadir
           mountPath: /server

--- a/charts/minecraft-proxy/templates/extraports-ing.yaml
+++ b/charts/minecraft-proxy/templates/extraports-ing.yaml
@@ -1,0 +1,44 @@
+{{- $proxyFullname := include "proxy.fullname" . }}
+{{- range .Values.minecraftProxy.extraPorts }}
+{{- if default "" .ingress.enabled }}
+{{- $servicePort := .service.port }}
+{{- $serviceName := printf "%s-%s" $proxyFullname .name }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+  {{- if .ingress.annotations }}
+  annotations: {{- toYaml .ingress.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    app: {{ $serviceName }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+spec:
+{{- if .ingress.tls }}
+  tls:
+  {{- range .ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .ingress.hosts }}
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ .path | default "/" }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ $servicePort }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/minecraft-proxy/templates/extraports-svc.yaml
+++ b/charts/minecraft-proxy/templates/extraports-svc.yaml
@@ -1,0 +1,42 @@
+{{- $proxyFullname := include "proxy.fullname" . }}
+{{- range .Values.minecraftProxy.extraPorts }}
+{{- if default "" .service.enabled }}
+{{- $serviceName := printf "%s-%s" $proxyFullname .name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $serviceName }}
+  annotations: {{ toYaml .service.annotations | nindent 4 }}
+  labels:
+    app: {{ $serviceName }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+spec:
+{{- if (or (eq .service.type "ClusterIP") (empty .service.type)) }}
+  type: ClusterIP
+{{- else if eq .service.type "LoadBalancer" }}
+  type: {{ .service.type }}
+  {{- if .service.loadBalancerIP }}
+  loadBalancerIP: {{ .service.loadBalancerIP }}
+  {{- end }}
+  {{- if .service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .service.type }}
+{{- end }}
+  {{- if .service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .service.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+  - name: {{ .name }}
+    port: {{ .service.port }}
+    targetPort: {{ .name }}
+    protocol: {{ .protocol }}
+  selector:
+    app: {{ $proxyFullname }}
+{{- end }}
+{{- end }}

--- a/charts/minecraft-proxy/templates/extraports-svc.yaml
+++ b/charts/minecraft-proxy/templates/extraports-svc.yaml
@@ -35,7 +35,11 @@ spec:
   - name: {{ .name }}
     port: {{ .service.port }}
     targetPort: {{ .name }}
+    {{- if .protocol }}
     protocol: {{ .protocol }}
+    {{- else }}
+    protocol: TCP
+    {{- end }}
   selector:
     app: {{ $proxyFullname }}
 {{- end }}

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -162,6 +162,34 @@ minecraftProxy:
     ## Set the externalTrafficPolicy in the Service to either Cluster or Local
     # externalTrafficPolicy: Cluster
 
+  extraPorts: []
+    # These options allow you to expose another port from the Minecraft proxy, plugins such
+    # as NuVotifier (8192) will require this for incoming webhooks
+    #
+    # - name: vote
+    #   containerPort: 8192
+    #   protocol: TCP
+    #   service:
+    #     enabled: false
+    #     annotations: {}
+    #     type: ClusterIP
+    #     loadBalancerIP: ""
+    #     loadBalancerSourceRanges: []
+    #     externalTrafficPolicy: Cluster
+    #     port: 8192
+    #   ingress:
+    #     enabled: false
+    #     annotations:
+    #       kubernetes.io/ingress.class: nginx
+    #       kubernetes.io/tls-acme: "true"
+    #     hosts:
+    #       - name: vote.local
+    #         path: /
+    #     tls:
+    #       - secretName: vote-tls
+    #         hosts:
+    #           - vote.local
+
 ## Additional minecraft container environment variables
 ##
 extraEnv: {}


### PR DESCRIPTION
Identical to the change to `minecraft`, to enable extra ports to be exposed to the proxy