### PR TITLE
feat(minecraft-proxy): add embedded service option to extraports

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.1.0
+version: 2.2.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/extraports-svc.yaml
+++ b/charts/minecraft-proxy/templates/extraports-svc.yaml
@@ -1,6 +1,6 @@
 {{- $proxyFullname := include "proxy.fullname" . }}
 {{- range .Values.minecraftProxy.extraPorts }}
-{{- if default "" .service.enabled }}
+{{- if and .service.enabled (not .service.embedded) }}
 {{- $serviceName := printf "%s-%s" $proxyFullname .name }}
 ---
 apiVersion: v1

--- a/charts/minecraft-proxy/templates/proxy-svc.yaml
+++ b/charts/minecraft-proxy/templates/proxy-svc.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -35,6 +36,18 @@ spec:
     nodePort: {{ .Values.minecraftProxy.nodePort }}
     {{- end }}
     protocol: TCP
+  {{- range .Values.minecraftProxy.extraPorts }}
+  {{- if and .service.enabled .service.embedded }}
+  - name: {{ .name }}
+    port: {{ .service.port }}
+    targetPort: {{ .name }}
+    {{- if .protocol }}
+    protocol: {{ .protocol }}
+    {{- else }}
+    protocol: TCP
+    {{- end }}
+  {{- end }}
+  {{- end }}
   selector:
     app: {{ template "proxy.fullname" . }}
   {{- if .Values.minecraftProxy.externalIPs }}

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -171,6 +171,7 @@ minecraftProxy:
     #   protocol: TCP
     #   service:
     #     enabled: false
+    #     embedded: false
     #     annotations: {}
     #     type: ClusterIP
     #     loadBalancerIP: ""


### PR DESCRIPTION
This allows you to embed the service port in the proxy service in the event you would like your extra ports to share the same service.
This is useful for sharing a single load balancer IP with MetalLB & still being able to use the Local external traffic policy to retain the origin IPs.