### PR TITLE
feat(minecraft): add embedded service option to extraports

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.2.0
+version: 3.3.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/extraports-svc.yaml
+++ b/charts/minecraft/templates/extraports-svc.yaml
@@ -1,6 +1,6 @@
 {{- $minecraftFullname := include "minecraft.fullname" . }}
 {{- range .Values.minecraftServer.extraPorts }}
-{{- if default "" .service.enabled }}
+{{- if and .service.enabled (not .service.embedded) }}
 {{- $serviceName := printf "%s-%s" $minecraftFullname .name }}
 ---
 apiVersion: v1

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -35,6 +35,18 @@ spec:
     nodePort: {{ .Values.minecraftServer.nodePort }}
     {{- end }}
     protocol: TCP
+  {{- range .Values.minecraftServer.extraPorts }}
+  {{- if and .service.enabled .service.embedded }}
+  - name: {{ .name }}
+    port: {{ .service.port }}
+    targetPort: {{ .name }}
+    {{- if .protocol }}
+    protocol: {{ .protocol }}
+    {{- else }}
+    protocol: TCP
+    {{- end }}
+  {{- end }}
+  {{- end }}
   selector:
     app: {{ template "minecraft.fullname" . }}
   {{- if .Values.minecraftServer.externalIPs }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -196,6 +196,7 @@ minecraftServer:
     #   protocol: TCP
     #   service:
     #     enabled: false
+    #     embedded: false
     #     annotations: {}
     #     type: ClusterIP
     #     loadBalancerIP: ""


### PR DESCRIPTION
As per #78, but for the `minecraft` chart