### PR TITLE
Fix kubeversion check in helper template

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.2.0
+version: 2.2.1
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.2.1
+version: 2.2.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.4.0
+version: 3.4.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -16,9 +16,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "minecraft.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1" -}}


### PR DESCRIPTION
Fixes issue introduced with #60.  It looks like `.Capabilities.KubeVersion.GitVersion` [has been deprecated](https://github.com/helm/helm/blob/2f4ef705a9e8ea0e38a2c99c29c5e4de59b03d75/pkg/chartutil/capabilities.go#L60) and we should use  `.Capabilities.KubeVersion.Version` instead.