### PR TITLE
Include `envFrom` and `env.value.valueFrom` in deployments

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 1.1.9
+version: 1.2.0
 appVersion: 1.16
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: minecraft-bedrock
 version: 1.2.0
-appVersion: 1.16
+appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server
 keywords:

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -65,6 +65,11 @@ spec:
                 # force health check against IPv4 port
                 - 127.0.0.1
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+
+      {{- with .Values.envFrom }}
+        envFrom:
+          {{- . | toYaml | nindent 10 }}{{ end }}
+
         env:
         - name: EULA
           value: {{ .Values.minecraftServer.eula | quote }}
@@ -110,10 +115,19 @@ spec:
           value: {{ .Values.minecraftServer.texturepackRequired | quote }}
         - name: ONLINE_MODE
           value: {{ .Values.minecraftServer.onlineMode | quote }}
-        {{- range $key, $value := .Values.extraEnv }}
+
+      {{- range $key, $value := .Values.extraEnv }}
+      {{-   if kindIs "map" $value }}
+      {{-     if hasKey $value "valueFrom" }}
         - name: {{ $key }}
-          value: {{ $value }}
-        {{- end }}
+          valueFrom:
+            {{- $value.valueFrom | toYaml | nindent 12 }}
+      {{-     end }}
+      {{-   else }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+      {{-   end }}
+      {{- end }}
 
         ports:
         - name: minecraft

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -118,8 +118,20 @@ minecraftServer:
   # externalTrafficPolicy: Cluster
 
 ## Additional minecraft container environment variables
+## Values can be either variable values or `valueFrom` yaml
 ##
-extraEnv: {}
+extraEnv:
+  {}
+  # some_variable: some value
+  # another_variable:
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: status.hostIP
+
+## Additional environment variables to add to the minecraft container from
+## ConfigMaps and Secrets
+##
+envFrom: []
 
 persistence:
   ## minecraft data Persistent Volume Storage Class

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.4.2
+version: 3.5.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+      {{- with .Values.envFrom }}
+        envFrom:
+          {{- . | toYaml | nindent 10 }}{{ end }}
         env:
         - name: EULA
           value: {{ .Values.minecraftServer.eula | quote }}
@@ -200,10 +203,18 @@ spec:
           value: {{ .Values.minecraftServer.query.port | quote }}
         {{- end }}
 
-        {{- range $key, $value := .Values.extraEnv }}
+      {{- range $key, $value := .Values.extraEnv }}
+      {{-   if kindIs "map" $value }}
+      {{-     if hasKey $value "valueFrom" }}
+        - name: {{ $key }}
+          valueFrom:
+            {{- $value.valueFrom | toYaml | nindent 12 }}
+      {{-     end }}
+      {{-   else }}
         - name: {{ $key }}
           value: {{ $value | quote }}
-        {{- end }}
+      {{-   end }}
+      {{- end }}
 
         ports:
         - name: minecraft

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -187,7 +187,8 @@ minecraftServer:
     ## Set the externalTrafficPolicy in the Service to either Cluster or Local
     # externalTrafficPolicy: Cluster
 
-  extraPorts: []
+  extraPorts:
+    []
     # These options allow you to expose another port from the Minecraft server, plugins such
     # as dynmap (8123) and bluemap (8100) will require this for access to their web interfaces
     #
@@ -222,8 +223,20 @@ minecraftServer:
     port: 25565
 
 ## Additional minecraft container environment variables
+## Values can be either variable values or `valueFrom` yaml
 ##
-extraEnv: {}
+extraEnv:
+  {}
+  # some_variable: some value
+  # another_variable:
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: status.hostIP
+
+## Additional environment variables to add to the minecraft container from
+## ConfigMaps and Secrets
+##
+envFrom: []
 
 persistence:
   annotations: {}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -187,8 +187,8 @@ minecraftServer:
     ## Set the externalTrafficPolicy in the Service to either Cluster or Local
     # externalTrafficPolicy: Cluster
 
-  extraPorts:
-    []
+  extraPorts: []
+
     # These options allow you to expose another port from the Minecraft server, plugins such
     # as dynmap (8123) and bluemap (8100) will require this for access to their web interfaces
     #


### PR DESCRIPTION
## What

- Add optional `envFrom` to deployments
- Update `extraEnv` to allow for setting `valueFrom` in env var specs

Fixes #71 