### PR TITLE
Add ingressClassName to templates

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.2.0
+version: 2.3.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/extraports-ing.yaml
+++ b/charts/minecraft-proxy/templates/extraports-ing.yaml
@@ -17,6 +17,9 @@ metadata:
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 spec:
+{{- if .ingress.ingressClassName }}
+  ingressClassName: {{ .ingress.ingressClassName }}
+{{- end }}
 {{- if .ingress.tls }}
   tls:
   {{- range .ingress.tls }}

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -179,9 +179,11 @@ minecraftProxy:
     #     externalTrafficPolicy: Cluster
     #     port: 8192
     #   ingress:
+    #     ingressClassName: nginx
     #     enabled: false
     #     annotations:
-    #       kubernetes.io/ingress.class: nginx
+    ## Deprecated way for specifying the ingressClass. Kube.version < 1.18
+    ##       kubernetes.io/ingress.class: nginx
     #       kubernetes.io/tls-acme: "true"
     #     hosts:
     #       - name: vote.local

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.5.0
+version: 3.6.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/extraports-ing.yaml
+++ b/charts/minecraft/templates/extraports-ing.yaml
@@ -17,6 +17,9 @@ metadata:
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 spec:
+{{- if .ingress.ingressClassName }}
+  ingressClassName: {{ .ingress.ingressClassName }}
+{{- end }}
 {{- if .ingress.tls }}
   tls:
   {{- range .ingress.tls }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -205,9 +205,11 @@ minecraftServer:
     #     externalTrafficPolicy: Cluster
     #     port: 8123
     #   ingress:
+    #     ingressClassName: nginx
     #     enabled: false
     #     annotations:
-    #       kubernetes.io/ingress.class: nginx
+    ## Deprecated way for specifying the ingressClass. Kube.version < 1.18
+    ##       kubernetes.io/ingress.class: nginx
     #       kubernetes.io/tls-acme: "true"
     #     hosts:
     #       - name: map.local


### PR DESCRIPTION
Add the field `ingressClassName` into the Ingress oject generated from the Chart templates. This is to support the use of IngressClass objects that replace the use of annotations (https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) when specifying the Ingress Controller to use.

The behavior can be tested using the helm chart from (https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx) `v4.0.6` with this example `values.yaml`:
```yaml
controller:
  watchIngressWithoutClass: false
  ingressClassByName: true
  electionID: ingress-controller-custom
  ingressClassResource:
    name: custom-nginx
    enabled: true
    default: false
    controllerValue: "k8s.io/custom-ingress-nginx"
  service:
    externalIPs: 
      - *your_ip*
  replicaCount: 1
```