### PR TITLE
add nodePort option for extraPorts

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.4.0
+version: 2.5.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/extraports-svc.yaml
+++ b/charts/minecraft-proxy/templates/extraports-svc.yaml
@@ -37,6 +37,7 @@ spec:
     targetPort: {{ .name }}
     {{- if .service.nodePort }}
     nodePort: {{ .service.nodePort }}
+    {{- end }}
     {{- if .protocol }}
     protocol: {{ .protocol }}
     {{- else }}

--- a/charts/minecraft-proxy/templates/extraports-svc.yaml
+++ b/charts/minecraft-proxy/templates/extraports-svc.yaml
@@ -35,6 +35,8 @@ spec:
   - name: {{ .name }}
     port: {{ .service.port }}
     targetPort: {{ .name }}
+    {{- if .service.nodePort }}
+    nodePort: {{ .service.nodePort }}
     {{- if .protocol }}
     protocol: {{ .protocol }}
     {{- else }}

--- a/charts/minecraft-proxy/templates/proxy-svc.yaml
+++ b/charts/minecraft-proxy/templates/proxy-svc.yaml
@@ -43,6 +43,7 @@ spec:
     targetPort: {{ .name }}
     {{- if .service.nodePort }}
     nodePort: {{ .service.nodePort }}
+    {{- end }}
     {{- if .protocol }}
     protocol: {{ .protocol }}
     {{- else }}

--- a/charts/minecraft-proxy/templates/proxy-svc.yaml
+++ b/charts/minecraft-proxy/templates/proxy-svc.yaml
@@ -41,6 +41,8 @@ spec:
   - name: {{ .name }}
     port: {{ .service.port }}
     targetPort: {{ .name }}
+    {{- if .service.nodePort }}
+    nodePort: {{ .service.nodePort }}
     {{- if .protocol }}
     protocol: {{ .protocol }}
     {{- else }}

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -174,6 +174,8 @@ minecraftProxy:
     #     embedded: false
     #     annotations: {}
     #     type: ClusterIP
+    #     ## Set the external port if the rcon serviceType is NodePort
+    ##     nodePort:
     #     loadBalancerIP: ""
     #     loadBalancerSourceRanges: []
     #     externalTrafficPolicy: Cluster

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.6.3
+version: 3.7.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/extraports-svc.yaml
+++ b/charts/minecraft/templates/extraports-svc.yaml
@@ -37,6 +37,7 @@ spec:
     targetPort: {{ .name }}
     {{- if .service.nodePort }}
     nodePort: {{ .service.nodePort }}
+    {{- end }}
     {{- if .protocol }}
     protocol: {{ .protocol }}
     {{- else }}

--- a/charts/minecraft/templates/extraports-svc.yaml
+++ b/charts/minecraft/templates/extraports-svc.yaml
@@ -35,6 +35,8 @@ spec:
   - name: {{ .name }}
     port: {{ .service.port }}
     targetPort: {{ .name }}
+    {{- if .service.nodePort }}
+    nodePort: {{ .service.nodePort }}
     {{- if .protocol }}
     protocol: {{ .protocol }}
     {{- else }}

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -42,6 +42,7 @@ spec:
     targetPort: {{ .name }}
     {{- if .service.nodePort }}
     nodePort: {{ .service.nodePort }}
+    {{- end }}
     {{- if .protocol }}
     protocol: {{ .protocol }}
     {{- else }}

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -40,6 +40,8 @@ spec:
   - name: {{ .name }}
     port: {{ .service.port }}
     targetPort: {{ .name }}
+    {{- if .service.nodePort }}
+    nodePort: {{ .service.nodePort }}
     {{- if .protocol }}
     protocol: {{ .protocol }}
     {{- else }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -202,6 +202,8 @@ minecraftServer:
     #     embedded: false
     #     annotations: {}
     #     type: ClusterIP
+          ## Set the external port if the rcon serviceType is NodePort
+    #     nodePort:
     #     loadBalancerIP: ""
     #     loadBalancerSourceRanges: []
     #     externalTrafficPolicy: Cluster

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -202,8 +202,8 @@ minecraftServer:
     #     embedded: false
     #     annotations: {}
     #     type: ClusterIP
-          ## Set the external port if the rcon serviceType is NodePort
-    #     nodePort:
+    #     ## Set the external port if the rcon serviceType is NodePort
+    ##     nodePort:
     #     loadBalancerIP: ""
     #     loadBalancerSourceRanges: []
     #     externalTrafficPolicy: Cluster


### PR DESCRIPTION
I noticed that unlike other instances in the charts to expose services, you cannot specify a specific `nodePort`, if required, on the `extraPorts` service collection.  I had to edit the svc in kubernetes to specify this directly.  This PR will allow you to specify that in the `values.yaml` and avoid that direct edit in the kubernetes manifests to be overridden.