### PR TITLE
Add rcloneDestDir param

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.7.2
+version: 3.8.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -92,6 +92,8 @@ spec:
         {{- if eq .Values.mcbackup.backupMethod "rclone" }}
         - name: RCLONE_REMOTE
           value: {{ .Values.mcbackup.rcloneRemote | quote }}
+        - name: RCLONE_DEST_DIR
+          value: {{ .Values.mcbackup.rcloneDestDir | quote }}
         - name: RCLONE_COMPRESS_METHOD
           value: {{ default "gzip" .Values.mcbackup.rcloneCompressMethod | quote }}
         {{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -331,6 +331,7 @@ mcbackup:
   zstdParameters: "-3 --long=25 --single-thread"
   # the name of the remote you've configured in your rclone.conf
   rcloneRemote:
+  rcloneDestDir:
   rcloneCompressMethod: gzip
 
   # see https://rclone.org/ for details


### PR DESCRIPTION
Companion PR to itzg/docker-mc-backup#63. Add an `rcloneDestDir` param to the chart, mapped to the `RCLONE_DEST_DIR` environment variable for `mc-backup`.

Fixes #104.