### PR TITLE
fix: Check if extraVolumes.volumeMounts is defined

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 1.2.0
+version: 1.2.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -138,7 +138,9 @@ spec:
         - name: datadir
           mountPath: /data
         {{- range .Values.extraVolumes }}
-        {{- toYaml .volumeMounts | nindent 8 }}
+        {{-   if .volumeMounts }}
+        {{-     toYaml .volumeMounts | nindent 8 }}
+        {{-   end }}
         {{- end }}
       volumes:
       - name: datadir

--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.5.0
+version: 2.5.1
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -151,7 +151,9 @@ spec:
           subPath: config.yml
         {{- end }}
         {{- range .Values.extraVolumes }}
-        {{- toYaml .volumeMounts | nindent 8 }}
+        {{-   if .volumeMounts }}
+        {{-     toYaml .volumeMounts | nindent 8 }}
+        {{-   end }}
         {{- end }}
       volumes:
       - name: datadir

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.8.1
+version: 3.8.2
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -127,7 +127,9 @@ spec:
           mountPath: /config/rclone
         {{- end }}
         {{- range .Values.extraVolumes }}
-        {{- toYaml .volumeMounts | nindent 8 }}
+        {{-   if .volumeMounts }}
+        {{-     toYaml .volumeMounts | nindent 8 }}
+        {{-   end }}
         {{- end }}
       {{- end }}
       - name: {{ template "minecraft.fullname" . }}
@@ -334,7 +336,9 @@ spec:
           mountPath: {{ default "/backups" .Values.mcbackup.destDir }}
           readOnly: true
         {{- range .Values.extraVolumes }}
-        {{- toYaml .volumeMounts | nindent 8 }}
+        {{-   if .volumeMounts }}
+        {{-     toYaml .volumeMounts | nindent 8 }}
+        {{-   end }}
         {{- end }}
       {{- if .Values.sidecarContainers }}
       {{- toYaml .Values.sidecarContainers | nindent 6 }}


### PR DESCRIPTION
It could be useful to create volumes without actually mounting them in
case if they are used exclusively for init containers