### PR TITLE
Update charts to standard image.repo and image.tag

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 1.2.1
+version: 1.3.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 1.3.0
+version: 2.0.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: {{ template "minecraft.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         stdin: true
         tty: true
         resources:

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -31,9 +31,9 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      {{- if .Values.imagePullSecret }}
+      {{- if .Values.image.pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.imagePullSecret }}
+        - name: {{ .Values.image.pullSecret }}
       {{- end }}
       {{- if .Values.initContainers }}
       initContainers:
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "minecraft.fullname" . }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: Always
         stdin: true
         tty: true

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -1,7 +1,9 @@
 # ref: https://hub.docker.com/r/itzg/minecraft-server/
-image: itzg/minecraft-bedrock-server
-imageTag: latest
-imagePullSecret: ""
+image:
+  repository: itzg/minecraft-bedrock-server
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecret: ""
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.6.0
+version: 2.7.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 2.7.0
+version: 3.0.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -23,9 +23,9 @@ spec:
       {{- if .Values.serviceAcccoutName }}
       serviceAccountName: {{ .Values.serviceAccountName }}
       {{- end }}
-      {{- if .Values.imagePullSecret }}
+      {{- if .Values.image.pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.imagePullSecret }}
+        - name: {{ .Values.image.pullSecret }}
       {{- end }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -33,7 +33,7 @@ spec:
       initContainers: {{- toYaml .Values.initContainers | nindent 8 }}
       containers:
       - name: {{ template "proxy.fullname" . }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: Always
         resources: {{ toYaml .Values.resources | nindent 10 }}
         {{- if .Values.startupProbe.enabled }}

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -1,7 +1,8 @@
 # ref: https://hub.docker.com/r/itzg/docker-bungeecord/
-image: itzg/bungeecord
-imageTag: latest
-imagePullSecret: ""
+image:
+  repository: itzg/bungeecord
+  tag: latest
+  pullSecret: ""
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -2,7 +2,9 @@
 image:
   repository: itzg/bungeecord
   tag: latest
-  pullSecret: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecret: ""
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.10.0
+version: 3.11.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 3.11.0
+version: 4.0.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       {{- if and .Values.mcbackup.enabled .Values.minecraftServer.rcon.enabled }}
       - name: {{ template "minecraft.fullname" . }}-mc-backup
         image: "{{ .Values.mcbackup.image.repository }}:{{ .Values.mcbackup.image.tag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.mcbackup.image.pullPolicy }}
         resources:
 {{ toYaml .Values.mcbackup.resources | indent 10 }}
         env:
@@ -134,7 +134,7 @@ spec:
       {{- end }}
       - name: {{ template "minecraft.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- if .Values.startupProbe.enabled }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -32,9 +32,9 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      {{- if .Values.imagePullSecret }}
+      {{- if .Values.image.pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.imagePullSecret }}
+        - name: {{ .Values.image.pullSecret }}
       {{- end }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -46,7 +46,7 @@ spec:
       containers:
       {{- if and .Values.mcbackup.enabled .Values.minecraftServer.rcon.enabled }}
       - name: {{ template "minecraft.fullname" . }}-mc-backup
-        image: "{{ .Values.mcbackup.image }}:{{ .Values.mcbackup.imageTag }}"
+        image: "{{ .Values.mcbackup.image.repository }}:{{ .Values.mcbackup.image.tag }}"
         imagePullPolicy: Always
         resources:
 {{ toYaml .Values.mcbackup.resources | indent 10 }}
@@ -133,7 +133,7 @@ spec:
         {{- end }}
       {{- end }}
       - name: {{ template "minecraft.fullname" . }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: Always
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -1,7 +1,9 @@
 # ref: https://hub.docker.com/r/itzg/minecraft-server/
-image: itzg/minecraft-server
-imageTag: latest
-imagePullSecret: ""
+image:
+  repository: itzg/minecraft-server
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecret: ""
 
 # ### WARNING ###
 # Minecraft is not horizontally scalable, adjusting this will most likely break your setup.
@@ -301,8 +303,9 @@ rconServiceAnnotations: {}
 mcbackup:
   enabled: false
 
-  image: itzg/mc-backup
-  imageTag: latest
+  image:
+    repository: itzg/mc-backup
+    tag: latest
 
   #  wait 2 minutes before starting
   initialDelay: 2m

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -306,6 +306,7 @@ mcbackup:
   image:
     repository: itzg/mc-backup
     tag: latest
+    pullPolicy: IfNotPresent
 
   #  wait 2 minutes before starting
   initialDelay: 2m

--- a/charts/rcon-web-admin/Chart.yaml
+++ b/charts/rcon-web-admin/Chart.yaml
@@ -3,7 +3,7 @@ name: rcon-web-admin
 home: https://github.com/rcon-web-admin/rcon-web-admin
 description: RCon Web UI for managing game servers
 type: application
-version: 0.2.0
+version: 1.0.0
 appVersion: "0.14.1-1"
 keywords:
   - game

--- a/charts/rcon-web-admin/Chart.yaml
+++ b/charts/rcon-web-admin/Chart.yaml
@@ -3,7 +3,7 @@ name: rcon-web-admin
 home: https://github.com/rcon-web-admin/rcon-web-admin
 description: RCon Web UI for managing game servers
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.14.1-1"
 keywords:
   - game

--- a/charts/rcon-web-admin/templates/deployment.yaml
+++ b/charts/rcon-web-admin/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         {{- include "rcon-web-admin.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
This PR updates the charts to utilize the current standard format for the image definition:

```yaml
image:
  repository:
  tag:
  pullPolicy:
```

It should be non-breaking for those using the default `values.yaml` for the image portion of the chart.

What this does allow for, since it's the Helm standard format, is automation that is build around this standard for helm charts can be utilized.