### PR TITLE
Rename `spigetResources` in `minecraft` chart to `spigotResources`

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.1.0
+version: 5.0.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -268,9 +268,9 @@ spec:
           value: "TRUE"
         {{- end }}
         {{- end }}
-        {{- if .Values.minecraftServer.spigetResources }}
-        - name: SPIGET_RESOURCES
-          value: {{ join "," .Values.minecraftServer.spigetResources | quote }}
+        {{- if .Values.minecraftServer.spigotResources }}
+        - name: SPIGOT_RESOURCES
+          value: {{ join "," .Values.minecraftServer.spigotResources | quote }}
         {{- end }}
         {{- if .Values.minecraftServer.vanillaTweaksShareCodes }}
         - name: VANILLATWEAKS_SHARECODE

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -208,7 +208,7 @@ minecraftServer:
   externalIPs:
 
   # A list of Spigot resources/plugins IDs to download.
-  spigetResources: []
+  spigotResources: []
 
   rcon:
     # If you enable this, make SURE to change your password below.


### PR DESCRIPTION
This PR addresses an incorrectly named value in the `minecraft` Helm chart called `spigetResources` which pulls Spigot plugins from spigotmc.org.

It also bumps the chart version to `5.0.0` as I believe this change should be considered breaking as I suspect many users would have encountered this typo and simply worked around it by using `spigetResources`.

Existing deployments with locked chart versions will be unaffected by this change, and deployments backed by PVC will also be unaffected.

However for new plugins to be installed when transitioning to version `5.0.0` on existing deployments users will need to use the new `spigotResources` value instead of `spigetResources`.