### PR TITLE
BUGFIX: Resource Pack support on minecraft-server chart

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.1.0
+version: 4.2.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -275,6 +275,7 @@ spec:
         {{- if .Values.minecraftServer.vanillaTweaksShareCodes }}
         - name: VANILLATWEAKS_SHARECODE
           value: {{ join "," .Values.minecraftServer.vanillaTweaksShareCodes | quote }}
+        {{- end }}
         {{- if .Values.minecraftServer.resourcePackUrl }}
         - name: RESOURCE_PACK
           value: {{ .Values.minecraftServer.resourcePackUrl | quote }}
@@ -286,7 +287,6 @@ spec:
         {{- if .Values.minecraftServer.resourcePackEnforce }}
         - name: RESOURCE_PACK_ENFORCE
           value: "TRUE"
-        {{- end }}
         {{- end }}
         - name: ONLINE_MODE
           value: {{ .Values.minecraftServer.onlineMode | quote }}


### PR DESCRIPTION
Fixed a bug where `RESOURCE_PACK`, `RESOURCE_PACK_SHA1`, and `RESOURCE_PACK_ENFORCE` would not be set unless the user specified `vanillaTweaksShareCodes`.