### PR TITLE
Include envFrom and valueFrom in mcbackup deployment

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.5.0
+version: 4.6.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         imagePullPolicy: {{ .Values.mcbackup.image.pullPolicy }}
         resources:
 {{ toYaml .Values.mcbackup.resources | indent 10 }}
+      {{- with .Values.mcbackup.envFrom }}
+        envFrom:
+          {{- . | toYaml | nindent 10 }}{{ end }}
         env:
         - name: SRC_DIR
           value: "/data"
@@ -112,9 +115,18 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
+
         {{- range $key, $value := .Values.mcbackup.extraEnv }}
+        {{-   if kindIs "map" $value }}
+        {{-     if hasKey $value "valueFrom" }}
+        - name: {{ $key }}
+          valueFrom:
+            {{- $value.valueFrom | toYaml | nindent 12 }}
+        {{-     end }}
+        {{-   else }}
         - name: {{ $key }}
           value: {{ $value | quote }}
+        {{-   end }}
         {{- end }}
         volumeMounts:
         - name: datadir

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -387,10 +387,21 @@ mcbackup:
     []
     # RESTIC_PASSWORD: restic-password
 
-  extraEnvs:
-    []
-    # Can be set to the timezone to use for logging
-    # tz:
+  ## Additional minecraft container environment variables
+  ## Values can be either variable values or `valueFrom` yaml
+  ##
+  extraEnv:
+    {}
+    # some_variable: some value
+    # another_variable:
+    #   valueFrom:
+    #     fieldRef:
+    #       fieldPath: status.hostIP
+
+  ## Additional environment variables to add to the minecraft container from
+  ## ConfigMaps and Secrets
+  ##
+  envFrom: []
 
   resources:
     requests:


### PR DESCRIPTION
Similar to #87 and #71, this PR adds the ability to specify `extraEnv` and `valueFrom` for the backup sidecar.

This makes the interface consistent with the primary container. 