### PR TITLE
Fix the use of required call for FTBA packs

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.7.2
+version: 4.7.3
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -186,7 +186,7 @@ spec:
         {{- else if eq .Values.minecraftServer.type "PAPER" }}
 {{- template "minecraft.envMap" list "PAPER_DOWNLOAD_URL" .Values.minecraftServer.paperDownloadUrl  }}
         {{- else if eq .Values.minecraftServer.type "FTBA" }}
-{{- template "minecraft.envMap" list "FTB_MODPACK_ID" required "You must supply a minecraftserver.ftbModpackVersionID with type=FTBA" .Values.minecraftServer.ftbModpackId  }}
+{{- template "minecraft.envMap" list "FTB_MODPACK_ID" (required "You must supply a minecraftserver.ftbModpackVersionID with type=FTBA" .Values.minecraftServer.ftbModpackId)  }}
         {{- if .Values.minecraftServer.ftbModpackVersionId }}
 {{- template "minecraft.envMap" list "FTB_MODPACK_VERSION_ID" .Values.minecraftServer.ftbModpackVersionId  }}
         {{- end }}


### PR DESCRIPTION
Without this fix, installing an FTBA pack results in;
```
Helm install failed: template: minecraft/templates/deployment.yaml:189:54: executing "minecraft/templates/deployment.yaml" at <required>: wrong number of args for required: want 2 got 0
```