### PR TITLE
Fix rclone secret indent level

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.7.3
+version: 4.7.4
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -11,8 +11,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
+  rclone.conf: |-
 {{- if .Values.mcbackup.rcloneConfig }}
-  rclone.conf: {{ .Values.mcbackup.rcloneConfig | b64enc | quote }}
+{{ .Values.mcbackup.rcloneConfig | b64enc | quote | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -13,7 +13,7 @@ type: Opaque
 data:
   rclone.conf: |-
 {{- if .Values.mcbackup.rcloneConfig }}
-{{ tpl .Values.mcbackup.rcloneConfig . | indent 4 | b64enc | quote }}
+{{ tpl .Values.mcbackup.rcloneConfig . | b64enc | quote | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -13,7 +13,7 @@ type: Opaque
 data:
   rclone.conf: |-
 {{- if .Values.mcbackup.rcloneConfig }}
-{{ tpl .Values.mcbackup.rcloneConfig . | b64enc | quote | indent 4 }}
+{{ tpl .Values.mcbackup.rcloneConfig . | b64enc | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -11,9 +11,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  rclone.conf: |-
 {{- if .Values.mcbackup.rcloneConfig }}
-{{ tpl .Values.mcbackup.rcloneConfig . | b64enc | quote | indent 4 }}
+  rclone.conf: {{ .Values.mcbackup.rcloneConfig | b64enc | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -13,7 +13,7 @@ type: Opaque
 data:
   rclone.conf: |-
 {{- if .Values.mcbackup.rcloneConfig }}
-{{ .Values.mcbackup.rcloneConfig | b64enc | quote | indent 4 }}
+{{ tpl .Values.mcbackup.rcloneConfig . | b64enc | quote | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
[This line](https://github.com/itzg/minecraft-server-charts/blob/396272c804d39fb7ccf09be042ceadeed6e3b177/charts/minecraft/templates/rclone-secret.yaml#L16), `{{ tpl .Values.mcbackup.rcloneConfig . | indent 4 | b64enc | quote }}` looks like it has the order of operations wrong.

With values such as,
```
minecraftServer:
  rcon:
    enabled: true

mcbackup:
  enabled: true
  backupInterval: '48h'
  backupMethod: rclone
  rcloneConfig: |
    [remote]
    type = s3
    provider = Minio
    env_auth = false
```
The template gives invalid yaml `Error: YAML parse error on minecraft/templates/rclone-secret.yaml: error converting YAML to JSON: yaml: line 14: could not find expected ':'`

```
apiVersion: v1
kind: Secret
metadata:
  name: release-name-minecraft-rclone-config
  labels:
    app: release-name-minecraft
    chart: "minecraft-4.7.3"
    release: "release-name"
    heritage: "Helm"
type: Opaque
data:
  rclone.conf: |-
"ICAgIFtyZW1vdGVdCiAgICB0eXBlID0gczMKICAgIHByb3ZpZGVyID0gTWluaW8KICAgIGVudl9hdXRoID0gZmFsc2UKICAgIA=="
```