### PR TITLE
use strict security context

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 2.0.2
+version: 2.1.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.initContainers }}
       initContainers:
       {{- toYaml .Values.initContainers | nindent 8 }}
@@ -139,6 +141,8 @@ spec:
           protocol: UDP
 
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: datadir
           mountPath: /data
         {{- range .Values.extraVolumes }}
@@ -146,7 +150,11 @@ spec:
         {{-     toYaml .volumeMounts | nindent 8 }}
         {{-   end }}
         {{- end }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
       volumes:
+      - name: tmp
+        emptyDir: {}
       - name: datadir
       {{- if .Values.persistence.dataDir.enabled }}
         persistentVolumeClaim:

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -22,6 +22,21 @@ tolerations: []
 
 affinity: {}
 
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 3000
+  runAsNonRoot: true
+  fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
 # Most of these map to environment variables. See Minecraft for details:
 # https://hub.docker.com/r/itzg/minecraft-server/
 livenessProbe:

--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 3.2.0
+version: 3.3.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -28,8 +28,7 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers: {{- toYaml .Values.initContainers | nindent 8 }}
       containers:
       - name: {{ template "proxy.fullname" . }}
@@ -151,6 +150,8 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: datadir
           mountPath: /server
         {{- if .Values.minecraftProxy.config }}
@@ -163,10 +164,14 @@ spec:
         {{-     toYaml .volumeMounts | nindent 8 }}
         {{-   end }}
         {{- end }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
       {{- if .Values.sidecarContainers }}
       {{- toYaml .Values.sidecarContainers | nindent 6 }}
       {{- end }}
       volumes:
+      - name: tmp
+        emptyDir: {}
       - name: datadir
       {{- if .Values.persistence.dataDir.enabled }}
         persistentVolumeClaim:

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -14,11 +14,21 @@ resources:
     memory: 512Mi
     cpu: 500m
 
-securityContext:
-  # Security context settings
+podSecurityContext:
   runAsUser: 1000
-  runAsGroup: 1000
+  runAsGroup: 3000
+  runAsNonRoot: true
   fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
 # Most of these map to environment variables. See Minecraft for details:
 # https://hub.docker.com/r/itzg/docker-bungeecord/
 livenessProbe:
@@ -176,37 +186,37 @@ minecraftProxy:
     # externalTrafficPolicy: Cluster
 
   extraPorts: []
-    # These options allow you to expose another port from the Minecraft proxy, plugins such
-    # as NuVotifier (8192) will require this for incoming webhooks
-    #
-    # - name: vote
-    #   containerPort: 8192
-    #   protocol: TCP
-    #   service:
-    #     enabled: false
-    #     embedded: false
-    #     annotations: {}
-    #     type: ClusterIP
-    #     ## Set the external port if the rcon serviceType is NodePort
-    ##     nodePort:
-    #     loadBalancerIP: ""
-    #     loadBalancerSourceRanges: []
-    #     externalTrafficPolicy: Cluster
-    #     port: 8192
-    #   ingress:
-    #     ingressClassName: nginx
-    #     enabled: false
-    #     annotations:
-    ## Deprecated way for specifying the ingressClass. Kube.version < 1.18
-    ##       kubernetes.io/ingress.class: nginx
-    #       kubernetes.io/tls-acme: "true"
-    #     hosts:
-    #       - name: vote.local
-    #         path: /
-    #     tls:
-    #       - secretName: vote-tls
-    #         hosts:
-    #           - vote.local
+  # These options allow you to expose another port from the Minecraft proxy, plugins such
+  # as NuVotifier (8192) will require this for incoming webhooks
+  #
+  # - name: vote
+  #   containerPort: 8192
+  #   protocol: TCP
+  #   service:
+  #     enabled: false
+  #     embedded: false
+  #     annotations: {}
+  #     type: ClusterIP
+  #     ## Set the external port if the rcon serviceType is NodePort
+  ##     nodePort:
+  #     loadBalancerIP: ""
+  #     loadBalancerSourceRanges: []
+  #     externalTrafficPolicy: Cluster
+  #     port: 8192
+  #   ingress:
+  #     ingressClassName: nginx
+  #     enabled: false
+  #     annotations:
+  ## Deprecated way for specifying the ingressClass. Kube.version < 1.18
+  ##       kubernetes.io/ingress.class: nginx
+  #       kubernetes.io/tls-acme: "true"
+  #     hosts:
+  #       - name: vote.local
+  #         path: /
+  #     tls:
+  #       - secretName: vote-tls
+  #         hosts:
+  #           - vote.local
 
 ## Additional minecraft container environment variables
 ## Values can be either variable values or `valueFrom` yaml

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.7.4
+version: 4.8.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -47,8 +47,7 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.initContainers }}
       initContainers:
       {{- toYaml .Values.initContainers | nindent 8 }}
@@ -119,6 +118,8 @@ spec:
         {{-   end }}
         {{- end }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: datadir
           mountPath: /data
           readOnly: true
@@ -133,6 +134,8 @@ spec:
         {{-     toYaml .volumeMounts | nindent 8 }}
         {{-   end }}
         {{- end }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
       {{- end }}
       - name: {{ template "minecraft.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -321,7 +324,7 @@ spec:
         {{- end }}
     {{- end }}
     {{- end }}
-        
+
 
       {{- range $key, $value := .Values.extraEnv }}
       {{-   if kindIs "map" $value }}
@@ -357,6 +360,8 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: datadir
           mountPath: /data
           {{- if (and .Values.persistence.dataDir.enabled .Values.persistence.dataDir.subPath) }}
@@ -370,10 +375,14 @@ spec:
         {{-     toYaml .volumeMounts | nindent 8 }}
         {{-   end }}
         {{- end }}
+        securityContext:
+            {{- toYaml .Values.securityContext | nindent 10 }}
       {{- if .Values.sidecarContainers }}
       {{- toYaml .Values.sidecarContainers | nindent 6 }}
       {{- end }}
       volumes:
+      - name: tmp
+        emptyDir: {}
       - name: datadir
       {{- if .Values.persistence.dataDir.enabled }}
         persistentVolumeClaim:

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -27,10 +27,21 @@ tolerations: []
 
 affinity: {}
 
-securityContext:
-  # Security context settings
+podSecurityContext:
   runAsUser: 1000
+  runAsGroup: 3000
+  runAsNonRoot: true
   fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
 # Most of these map to environment variables. See Minecraft for details:
 # https://hub.docker.com/r/itzg/minecraft-server/
 livenessProbe:

--- a/charts/rcon-web-admin/Chart.yaml
+++ b/charts/rcon-web-admin/Chart.yaml
@@ -3,7 +3,7 @@ name: rcon-web-admin
 home: https://github.com/rcon-web-admin/rcon-web-admin
 description: RCon Web UI for managing game servers
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "0.14.1-1"
 keywords:
   - game

--- a/charts/rcon-web-admin/templates/deployment.yaml
+++ b/charts/rcon-web-admin/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
       serviceAccountName: {{ include "rcon-web-admin.fullname" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: db
+          emptyDir: {}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -35,7 +38,7 @@ spec:
             - name: RWA_USERNAME
               value: {{ .Values.rconWeb.username | default "admin" | quote }}
             - name: RWA_PASSWORD
-              valueFrom: 
+              valueFrom:
                 secretKeyRef:
                   name: {{ .Values.rconWeb.passwordExistingSecret | default (include "rcon-web-admin.fullname" .) }}
                   key: {{ .Values.rconWeb.passwordKey | default "password" }}
@@ -102,6 +105,9 @@ spec:
             - name: ws
               containerPort: 4327
               protocol: TCP
+          volumeMounts:
+            - name: db
+              mountPath: /opt/rcon-web-admin/db
           livenessProbe:
             httpGet:
               path: /

--- a/charts/rcon-web-admin/values.yaml
+++ b/charts/rcon-web-admin/values.yaml
@@ -17,17 +17,19 @@ fullnameOverride: ""
 podAnnotations: {}
 
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  runAsUser: 1000
+  runAsGroup: 3000
+  runAsNonRoot: true
+  fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
 
 # This will expose 2 different services - http and websockets
 # If you want to know why it's separate - ask developer of original project


### PR DESCRIPTION
Use a strict security context by default to comply with the restricted pod security policy.

Fixes #154