### PR TITLE
minecraft: allow for boolean values to be defaulted

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.8.0
+version: 4.9.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -31,3 +31,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
           value: {{ index . 1 | quote }}
 {{- end }}
 {{- end }}
+
+{{- define "minecraft.envBoolMap" }}
+{{- if ne (toString (index . 1)) "default" }}
+        - name: {{ index . 0 }}
+          value: {{ index . 1 | quote }}
+{{- end }}
+{{- end }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -195,7 +195,7 @@ spec:
         {{- end }}
         {{- else if eq .Values.minecraftServer.type "CURSEFORGE" }}
 {{- template "minecraft.envMap" list "CF_SERVER_MOD" .Values.minecraftServer.cfServerMod  }}
-{{- template "minecraft.envMap" list "FTB_LEGACYJAVAFIXER" .Values.minecraftServer.ftbLegacyJavaFixer  }}
+{{- template "minecraft.envBoolMap" list "FTB_LEGACYJAVAFIXER" .Values.minecraftServer.ftbLegacyJavaFixer  }}
         {{- end }}
 {{- template "minecraft.envMap" list "VERSION" .Values.minecraftServer.version  }}
 {{- template "minecraft.envMap" list "DIFFICULTY" .Values.minecraftServer.difficulty  }}
@@ -204,27 +204,27 @@ spec:
 {{- template "minecraft.envMap" list "ICON" .Values.minecraftServer.icon  }}
 {{- template "minecraft.envMap" list "MAX_PLAYERS" .Values.minecraftServer.maxPlayers  }}
 {{- template "minecraft.envMap" list "MAX_WORLD_SIZE" .Values.minecraftServer.maxWorldSize  }}
-{{- template "minecraft.envMap" list "ALLOW_NETHER" .Values.minecraftServer.allowNether  }}
-{{- template "minecraft.envMap" list "ANNOUNCE_PLAYER_ACHIEVEMENTS" .Values.minecraftServer.announcePlayerAchievements  }}
-{{- template "minecraft.envMap" list "ENABLE_COMMAND_BLOCK" .Values.minecraftServer.enableCommandBlock  }}
-{{- template "minecraft.envMap" list "FORCE_GAMEMODE" .Values.minecraftServer.forcegameMode  }}
+{{- template "minecraft.envBoolMap" list "ALLOW_NETHER" .Values.minecraftServer.allowNether  }}
+{{- template "minecraft.envBoolMap" list "ANNOUNCE_PLAYER_ACHIEVEMENTS" .Values.minecraftServer.announcePlayerAchievements  }}
+{{- template "minecraft.envBoolMap" list "ENABLE_COMMAND_BLOCK" .Values.minecraftServer.enableCommandBlock  }}
+{{- template "minecraft.envBoolMap" list "FORCE_GAMEMODE" .Values.minecraftServer.forcegameMode  }}
         {{- if .Values.minecraftServer.forceReDownload }}
         - name: FORCE_REDOWNLOAD
           value: "TRUE"
         {{- end }}
-{{- template "minecraft.envMap" list "GENERATE_STRUCTURES" .Values.minecraftServer.generateStructures  }}
-{{- template "minecraft.envMap" list "HARDCORE" .Values.minecraftServer.hardcore  }}
+{{- template "minecraft.envBoolMap" list "GENERATE_STRUCTURES" .Values.minecraftServer.generateStructures  }}
+{{- template "minecraft.envBoolMap" list "HARDCORE" .Values.minecraftServer.hardcore  }}
 {{- template "minecraft.envMap" list "MAX_BUILD_HEIGHT" .Values.minecraftServer.maxBuildHeight  }}
 {{- template "minecraft.envMap" list "MAX_TICK_TIME" .Values.minecraftServer.maxTickTime  }}
-{{- template "minecraft.envMap" list "SPAWN_ANIMALS" .Values.minecraftServer.spawnAnimals  }}
-{{- template "minecraft.envMap" list "SPAWN_MONSTERS" .Values.minecraftServer.spawnMonsters  }}
-{{- template "minecraft.envMap" list "SPAWN_NPCS" .Values.minecraftServer.spawnNPCs  }}
+{{- template "minecraft.envBoolMap" list "SPAWN_ANIMALS" .Values.minecraftServer.spawnAnimals  }}
+{{- template "minecraft.envBoolMap" list "SPAWN_MONSTERS" .Values.minecraftServer.spawnMonsters  }}
+{{- template "minecraft.envBoolMap" list "SPAWN_NPCS" .Values.minecraftServer.spawnNPCs  }}
 {{- template "minecraft.envMap" list "SPAWN_PROTECTION" .Values.minecraftServer.spawnProtection  }}
 {{- template "minecraft.envMap" list "VIEW_DISTANCE" .Values.minecraftServer.viewDistance  }}
 {{- template "minecraft.envMap" list "SEED" .Values.minecraftServer.levelSeed  }}
 {{- template "minecraft.envMap" list "MODE" .Values.minecraftServer.gameMode  }}
 {{- template "minecraft.envMap" list "MOTD" .Values.minecraftServer.motd  }}
-{{- template "minecraft.envMap" list "PVP" .Values.minecraftServer.pvp  }}
+{{- template "minecraft.envBoolMap" list "PVP" .Values.minecraftServer.pvp  }}
 {{- template "minecraft.envMap" list "LEVEL_TYPE" .Values.minecraftServer.levelType  }}
 {{- template "minecraft.envMap" list "GENERATOR_SETTINGS" .Values.minecraftServer.generatorSettings  }}
 {{- template "minecraft.envMap" list "LEVEL" .Values.minecraftServer.worldSaveName  }}
@@ -240,6 +240,9 @@ spec:
         {{- if .Values.minecraftServer.modUrls }}
 {{- template "minecraft.envMap" list "MODS" (join "," .Values.minecraftServer.modUrls) }}
         {{- end }}
+        {{- if .Values.minecraftServer.pluginUrls }}
+{{- template "minecraft.envMap" list "PLUGINS" (join "," .Values.minecraftServer.pluginUrls) }}
+        {{- end }}
         {{- if .Values.minecraftServer.spigetResources }}
 {{- template "minecraft.envMap" list "SPIGET_RESOURCES" (join "," .Values.minecraftServer.spigetResources) }}
         {{- end }}
@@ -250,7 +253,7 @@ spec:
 {{- template "minecraft.envMap" list "MODRINTH_PROJECTS" (join "," .projects) }}
         {{- end }}
         {{- if .optionalDependencies }}
-{{- template "minecraft.envMap" list "MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES" "TRUE" }}
+{{- template "minecraft.envMap" list "MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES" .optionalDependencies }}
         {{- end }}
 {{- template "minecraft.envMap" list "MODRINTH_ALLOWED_VERSION_TYPE" .allowedVersionType }}
     {{- end }}
@@ -269,25 +272,27 @@ spec:
         - name: RESOURCE_PACK_ENFORCE
           value: "TRUE"
         {{- end }}
-{{- template "minecraft.envMap" list "ONLINE_MODE" .Values.minecraftServer.onlineMode  }}
-{{- template "minecraft.envMap" list "ENFORCE_SECURE_PROFILE" .Values.minecraftServer.enforceSecureProfile  }}
+{{- template "minecraft.envBoolMap" list "ONLINE_MODE" .Values.minecraftServer.onlineMode  }}
+{{- template "minecraft.envBoolMap" list "ENFORCE_SECURE_PROFILE" .Values.minecraftServer.enforceSecureProfile  }}
 {{- template "minecraft.envMap" list "MEMORY" .Values.minecraftServer.memory  }}
 {{- template "minecraft.envMap" list "JVM_OPTS" .Values.minecraftServer.jvmOpts  }}
 {{- template "minecraft.envMap" list "JVM_XX_OPTS" .Values.minecraftServer.jvmXXOpts  }}
-{{- template "minecraft.envMap" list "OVERRIDE_SERVER_PROPERTIES" .Values.minecraftServer.overrideServerProperties  }}
+{{- template "minecraft.envBoolMap" list "OVERRIDE_SERVER_PROPERTIES" .Values.minecraftServer.overrideServerProperties  }}
 
-        {{- if .Values.minecraftServer.rcon.enabled }}
+{{- if .Values.minecraftServer.rcon.enabled }}
         - name: ENABLE_RCON
           value: "true"
+  {{- if not .Values.minecraftServer.rcon.withGeneratedPassword }}
         - name: RCON_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.minecraftServer.rcon.existingSecret | default (printf "%s-rcon" (include "minecraft.fullname" .)) }}
               key: {{ .Values.minecraftServer.rcon.secretKey | default "rcon-password" }}
-        {{- else }}
+  {{- end }}
+{{- else }}
         - name: ENABLE_RCON
           value: "false"
-        {{- end }}
+{{- end }}
         {{- if .Values.minecraftServer.query.enabled }}
         - name: ENABLE_QUERY
           value: "true"

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -5,6 +5,36 @@
         "minecraftServer": {
             "type": "object",
             "properties": {
+                "eula": {
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "enum": ["true", "TRUE", "false", "FALSE"]
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                "version": {"type": "string",
+                    "default": "LATEST",
+                    "title": "Minecraft version for all server types",
+                    "description": "Such as LATEST, SNAPSHOT, or a specific version. Refer to https://docker-minecraft-server.readthedocs.io/en/latest/versions/minecraft/"
+                },
+                "type": {"type": "string",
+                    "default": "VANILLA",
+                    "title": "Server type",
+                    "description": "Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/"
+                },
+                "difficulty": {
+                    "type": "string"
+                },
+                "maxPlayers": {
+                    "type": "integer"
+                },
+                "maxWorldSize": {
+                    "type": "integer"
+                },
                 "modrinth": {
                     "type": "object",
                     "required": ["projects"],
@@ -97,8 +127,54 @@
                             "type": "boolean"
                         }
                     }
-                }
-            }
+                },
+                "pluginUrls": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "maxBuildHeight": {
+                    "type": "integer"
+                },
+                "maxTickTime": {
+                    "type": "integer"
+                },
+                "spawnProtection": {
+                    "type": "integer"
+                },
+                "ftbLegacyJavaFixer": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "allowNether": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "announcePlayerAchievements": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "enableCommandBlock": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "forcegameMode": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "generateStructures": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "hardcore": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "spawnAnimals": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "spawnMonsters": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "spawnNPCs": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "pvp": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "onlineMode": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "enforceSecureProfile": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]},
+                "overrideServerProperties": {
+                    "anyOf": [{"type": "string", "enum": ["default"]}, {"type": "boolean"}]}
+            },
+            "required": [
+                "eula"
+            ]
         }
     }
 }

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -128,7 +128,7 @@ minecraftServer:
   # If type is set to CURSEFORGE, this sets the server mod to run. Can also provide url to curseforge package.
   cfServerMod:
   # Set to true if running Feed The Beast and get an error like "unable to launch forgemodloader"
-  ftbLegacyJavaFixer: false
+  ftbLegacyJavaFixer: default
   # One of: peaceful, easy, normal, and hard
   difficulty: easy
   # A comma-separated list of player names to whitelist.
@@ -142,27 +142,27 @@ minecraftServer:
   # This sets the maximum possible size in blocks, expressed as a radius, that the world border can obtain.
   maxWorldSize: 10000
   # Allows players to travel to the Nether.
-  allowNether: true
+  allowNether: default
   # Allows server to announce when a player gets an achievement.
-  announcePlayerAchievements: true
+  announcePlayerAchievements: default
   # Enables command blocks.
-  enableCommandBlock: true
+  enableCommandBlock: default
   # If true, players will always join in the default gameMode even if they were previously set to something else.
-  forcegameMode: false
+  forcegameMode: default
   # Defines whether structures (such as villages) will be generated.
-  generateStructures: true
+  generateStructures: default
   # If set to true, players will be set to spectator mode if they die.
-  hardcore: false
+  hardcore: default
   # The maximum height in which building is allowed.
   maxBuildHeight: 256
   # The maximum number of milliseconds a single tick may take before the server watchdog stops the server with the message. -1 disables this entirely.
   maxTickTime: 60000
   # Determines if animals will be able to spawn.
-  spawnAnimals: true
+  spawnAnimals: default
   # Determines if monsters will be spawned.
-  spawnMonsters: true
+  spawnMonsters: default
   # Determines if villagers will be spawned.
-  spawnNPCs: true
+  spawnNPCs: default
   # Sets the area that non-ops can not edit (0 to disable)
   spawnProtection: 16
   # Max view distance (in chunks).
@@ -174,7 +174,7 @@ minecraftServer:
   # Message of the Day
   motd: "Welcome to Minecraft on Kubernetes!"
   # If true, enable player-vs-player damage.
-  pvp: false
+  pvp: default
   # One of: DEFAULT, FLAT, LARGEBIOMES, AMPLIFIED, CUSTOMIZED
   levelType: DEFAULT
   # When levelType == FLAT or CUSTOMIZED, this can be used to further customize map generation.
@@ -199,9 +199,9 @@ minecraftServer:
   # When true, players will be prompted for a response and will be disconnected if they decline the required pack
   resourcePackEnforce: false
   # Check accounts against Minecraft account service.
-  onlineMode: true
+  onlineMode: default
   # Require public key to be signed by Mojang to join
-  enforceSecureProfile: true
+  enforceSecureProfile: default
   # If you adjust this, you may need to adjust resources.requests above to match.
   memory: 1024M
   # General JVM options to be passed to the Minecraft server invocation
@@ -229,6 +229,7 @@ minecraftServer:
   # List with URLs and paths to jar files, additionally may be a directory with jars
   # This works for both mods and plugins depending on server type
   modUrls: []
+  pluginUrls: []
 
   # A list of Spigot resources/plugins IDs to download.
   spigetResources: []
@@ -277,6 +278,10 @@ minecraftServer:
   rcon:
     # If you enable this, make SURE to change your password below.
     enabled: false
+    # By default, the container will generate a random password at startup
+    # to ensure internal RCON tooling, including a backup container,
+    # can be used, but the password is secure.
+    withGeneratedPassword: false
     port: 25575
     password: "CHANGEME!"
     existingSecret:


### PR DESCRIPTION
Also:
- introduces `minecraftServer.rcon.withGeneratedPassword` to support https://github.com/itzg/docker-minecraft-server/pull/2186

Resolves #153 