### PR TITLE
feat: Add container lifecycle to the main Minecraft container

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.9.0
+version: 4.9.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -142,6 +142,24 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         tty: true
         stdin: true
+        # Working here
+        {{- if or (.Values.lifecycle.postStart) (.Values.lifecycle.preStop)}}
+        lifecycle:
+          {{- if .Values.lifecycle.postStart }}
+          postStart:
+            exec:
+              command: {{- range .Values.lifecycle.postStart }}
+                - {{ . }}
+              {{- end }}
+          {{- end }}
+          {{- if .Values.lifecycle.preStop }}
+          preStop:
+            exec:
+              command: {{- range .Values.lifecycle.postStart }}
+                - {{ . }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- if .Values.startupProbe.enabled }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -142,7 +142,6 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         tty: true
         stdin: true
-        # Working here
         {{- if or (.Values.lifecycle.postStart) (.Values.lifecycle.preStop)}}
         lifecycle:
           {{- if .Values.lifecycle.postStart }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -19,8 +19,8 @@ resources:
     cpu: 500m
 
 lifecycle:
-  postStart: {}
-  preStop: {}
+  postStart: []
+  preStop: []
 
 # upgrade strategy type (e.g. Recreate or RollingUpdate)
 strategyType: Recreate

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -18,6 +18,10 @@ resources:
     memory: 512Mi
     cpu: 500m
 
+lifecycle:
+  postStart: {}
+  preStop: {}
+
 # upgrade strategy type (e.g. Recreate or RollingUpdate)
 strategyType: Recreate
 


### PR DESCRIPTION
It might be useful when a user wants to install plugins using `initContainers`, but those plugins require running some commands in order to be configured.

For example, I'm installing plugins in an `emptyDir` volume, so they are reinstalled on each pod restart. But since configs are stored in the same dir, I can't just edit them there, because they exist on that `emptyDir` volume as well. So the idea of this PR is to let users do something like:

```YAML
  spec:
    containers:
      name: minecraft-minecraft
      lifecycle:
        postStart:
          exec:
            command:
            - bash
            - -c
            - for i in {1..100}; do mc-health && break || sleep 20; done && mc-send-to-console
              say hello world
```