### PR TITLE
Added labels recomended in k8s docs

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,21 +1,21 @@
 apiVersion: v1
 name: minecraft
-version: 4.9.1
+version: 4.9.2
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server
 keywords:
-- game
-- server
+  - game
+  - server
 sources:
-- https://github.com/itzg/minecraft-server-charts
+  - https://github.com/itzg/minecraft-server-charts
 maintainers:
-- name: gtaylor
-  email: gtaylor@gc-taylor.com
-- name: billimek
-  email: jeff@billimek.com
-- name: itzg
-  email: itzgeoff@gmail.com
+  - name: gtaylor
+    email: gtaylor@gc-taylor.com
+  - name: billimek
+    email: jeff@billimek.com
+  - name: itzg
+    email: itzgeoff@gmail.com
 annotations:
   artifacthub.io/links: |
     - name: Image source

--- a/charts/minecraft/templates/backupdir-pvc.yaml
+++ b/charts/minecraft/templates/backupdir-pvc.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   annotations:
   {{- with .Values.mcbackup.persistence.annotations  }}
   {{ toYaml . | nindent 4 }}

--- a/charts/minecraft/templates/datadir-pvc.yaml
+++ b/charts/minecraft/templates/datadir-pvc.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   annotations:
   {{- with .Values.persistence.annotations  }}
   {{ toYaml . | nindent 4 }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -14,6 +14,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   {{- if .Values.deploymentLabels }}
     {{- range $key, $value := .Values.deploymentLabels}}
     {{ $key }}: {{ $value | quote }}
@@ -30,6 +33,9 @@ spec:
     metadata:
       labels:
         app: {{ template "minecraft.fullname" . }}
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
+        app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+        app.kubernetes.io/version: "{{ .Chart.Version }}"
       {{- if .Values.podLabels }}
         {{- range $key, $value := .Values.podLabels}}
         {{ $key }}: {{ $value | quote }}

--- a/charts/minecraft/templates/extraports-ing.yaml
+++ b/charts/minecraft/templates/extraports-ing.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ $minecraftFullname }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
 spec:
 {{- if .ingress.ingressClassName }}
   ingressClassName: {{ .ingress.ingressClassName }}

--- a/charts/minecraft/templates/extraports-svc.yaml
+++ b/charts/minecraft/templates/extraports-svc.yaml
@@ -13,6 +13,9 @@ metadata:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ $minecraftFullname }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
 spec:
 {{- if (or (eq .service.type "ClusterIP") (empty .service.type)) }}
   type: ClusterIP

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   {{- if .Values.serviceLabels }}
     {{- range $key, $value := .Values.serviceLabels}}
     {{ $key }}: {{ $value | quote }}

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
 type: Opaque
 data:
   rclone.conf: |-

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   {{- if .Values.rconServiceLabels }}
     {{- range $key, $value := .Values.rconServiceLabels}}
     {{ $key }}: {{ $value | quote }}

--- a/charts/minecraft/templates/secrets.yaml
+++ b/charts/minecraft/templates/secrets.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
 type: Opaque
 data:
   rcon-password: {{ default "" .Values.minecraftServer.rcon.password | b64enc | quote }}
@@ -24,6 +27,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
 type: Opaque
 data:
   cf-api-key: {{ default "" .Values.minecraftServer.autoCurseForge.apiKey.key | b64enc | quote }}


### PR DESCRIPTION
I wanted to write a ServiceMonitor that would collect metrics from all k8s services with matching labels, and I found out that there are no common labels, so I could select all instances of this chart. Added some of recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/