### PR TITLE
Option to deploy server as StatefulSet

### DIFF
--- a/charts/minecraft-bedrock/templates/datadir-pvc.yaml
+++ b/charts/minecraft-bedrock/templates/datadir-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim ) -}}
+{{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim ) (not .Values.workloadAsStatefulSet) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if ne (printf "%s" .Values.minecraftServer.eula) "FALSE" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ ternary "StatefulSet" "Deployment" .Values.workloadAsStatefulSet }}
 metadata:
   name: {{ template "minecraft.fullname" . }}
   {{- if .Values.deploymentAnnotations }}
@@ -15,8 +15,14 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  {{- if .Values.workloadAsStatefulSet }}
+  serviceName: {{ template "minecraft.fullname" . }}
+  updateStrategy:
+    type: {{ .Values.strategyType }}
+  {{- else }}
   strategy:
     type: {{ .Values.strategyType }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "minecraft.fullname" . }}
@@ -155,15 +161,19 @@ spec:
       volumes:
       - name: tmp
         emptyDir: {}
-      - name: datadir
       {{- if .Values.persistence.dataDir.enabled }}
+      {{- if .Values.persistence.dataDir.existingClaim }}
+      - name: datadir
         persistentVolumeClaim:
-        {{- if .Values.persistence.dataDir.existingClaim }}
           claimName: {{ .Values.persistence.dataDir.existingClaim }}
-        {{- else }}
+      {{- else if (not .Values.workloadAsStatefulSet) }}
+      - name: datadir
+        persistentVolumeClaim:
           claimName: {{ template "minecraft.fullname" . }}-datadir
-        {{- end }}
+      {{- end -}}
+      {{/* if persistence enabled in stateful set without existing claim, a volume claim template will be defined */}}
       {{- else }}
+      - name: datadir
         emptyDir: {}
       {{- end }}
       {{- range .Values.extraVolumes }}
@@ -181,4 +191,38 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
+  {{- if .Values.workloadAsStatefulSet }}
+  volumeClaimTemplates:
+    {{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim) }}
+    - metadata:
+        name: datadir   
+        labels:
+          app: {{ template "minecraft.fullname" . }}
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          release: "{{ .Release.Name }}"
+          heritage: "{{ .Release.Service }}"
+        annotations:
+        {{- with .Values.persistence.annotations  }}
+        {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.persistence.storageClass }}
+          volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+        {{- else }}
+          volume.alpha.kubernetes.io/storage-class: default
+        {{- end }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.persistence.dataDir.Size | quote }}
+      {{- if .Values.persistence.storageClass }}
+      {{- if (eq "-" .Values.persistence.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.persistence.storageClass }}"
+      {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{ end }}

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -13,7 +13,16 @@ resources:
     memory: 512Mi
     cpu: 500m
 
-# upgrade strategy type (e.g. Recreate or RollingUpdate)
+# If true the workload is defined as a StatefulSet instead of a Deployment.
+# Make sure to also update the strategyType!
+# All configuration options for the Deployment (e.g. annotations) are used for the StatefulSet.
+# Regarding persistence: When an existing PVC is provided it will be shared between all Pods.
+# Otherwise the PVC configuration is used as a template to create PVCs for each replica.
+workloadAsStatefulSet: false
+
+# upgrade strategy type, depending on workload type:
+# - for Deployment sets strategy: Recreate or RollingUpdate
+# - for StatefulSet sets updateStrategy: OnDelete or RollingUpdate
 strategyType: Recreate
 
 nodeSelector: {}

--- a/charts/minecraft/templates/backupdir-pvc.yaml
+++ b/charts/minecraft/templates/backupdir-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mcbackup.persistence.backupDir.enabled (not .Values.mcbackup.persistence.backupDir.existingClaim ) -}}
+{{- if and .Values.mcbackup.persistence.backupDir.enabled (not .Values.mcbackup.persistence.backupDir.existingClaim ) (not .Values.workloadAsStatefulSet) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/minecraft/templates/datadir-pvc.yaml
+++ b/charts/minecraft/templates/datadir-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim ) -}}
+{{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim ) (not .Values.workloadAsStatefulSet) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if ne (printf "%s" .Values.minecraftServer.eula) "FALSE" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ ternary "StatefulSet" "Deployment" .Values.workloadAsStatefulSet }}
 metadata:
   name: {{ template "minecraft.fullname" . }}
   {{- if .Values.deploymentAnnotations }}
@@ -24,8 +24,14 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ default 1 .Values.replicaCount }}
+  {{- if .Values.workloadAsStatefulSet }}
+  serviceName: {{ template "minecraft.fullname" . }}
+  updateStrategy:
+    type: {{ .Values.strategyType }}
+  {{- else }}
   strategy:
     type: {{ .Values.strategyType }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "minecraft.fullname" . }}
@@ -411,26 +417,34 @@ spec:
       volumes:
       - name: tmp
         emptyDir: {}
-      - name: datadir
       {{- if .Values.persistence.dataDir.enabled }}
+      {{- if .Values.persistence.dataDir.existingClaim }}
+      - name: datadir
         persistentVolumeClaim:
-        {{- if .Values.persistence.dataDir.existingClaim }}
           claimName: {{ .Values.persistence.dataDir.existingClaim }}
-        {{- else }}
+      {{- else if (not .Values.workloadAsStatefulSet) }}
+      - name: datadir
+        persistentVolumeClaim:
           claimName: {{ template "minecraft.fullname" . }}-datadir
-        {{- end }}
+      {{- end -}}
+      {{/* if persistence enabled in stateful set without existing claim, a volume claim template will be defined */}}
       {{- else }}
+      - name: datadir
         emptyDir: {}
       {{- end }}
-      - name: backupdir
       {{- if and .Values.mcbackup.persistence.backupDir.enabled .Values.mcbackup.enabled }}
+      {{- if .Values.mcbackup.persistence.backupDir.existingClaim }}
+      - name: backupdir
         persistentVolumeClaim:
-        {{- if .Values.mcbackup.persistence.backupDir.existingClaim }}
           claimName: {{ .Values.mcbackup.persistence.backupDir.existingClaim }}
-        {{- else }}
+      {{- else if (not .Values.workloadAsStatefulSet) }}
+      - name: backupdir
+        persistentVolumeClaim:
           claimName: {{ template "minecraft.fullname" . }}-backupdir
-        {{- end }}
+      {{- end -}}
+      {{/* if persistence enabled in stateful set without existing claim, a volume claim template will be defined */}}
       {{- else }}
+      - name: backupdir
         emptyDir: {}
       {{- end }}
       {{- if eq .Values.mcbackup.backupMethod "rclone" }}
@@ -462,4 +476,75 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
+  {{- if .Values.workloadAsStatefulSet }}
+  volumeClaimTemplates:
+    {{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim) }}
+    - metadata:
+        name: datadir   
+        labels:
+          app: {{ template "minecraft.fullname" . }}
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          release: "{{ .Release.Name }}"
+          heritage: "{{ .Release.Service }}"
+          app.kubernetes.io/name: "{{ .Chart.Name }}"
+          app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+          app.kubernetes.io/version: "{{ .Chart.Version }}"  
+        annotations:
+        {{- with .Values.persistence.annotations  }}
+        {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.persistence.storageClass }}
+          volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+        {{- else }}
+          volume.alpha.kubernetes.io/storage-class: default
+        {{- end }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.persistence.dataDir.Size | quote }}
+      {{- if .Values.persistence.storageClass }}
+      {{- if (eq "-" .Values.persistence.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.persistence.storageClass }}"
+      {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if and .Values.mcbackup.persistence.backupDir.enabled (not .Values.mcbackup.persistence.backupDir.existingClaim) }}
+    - metadata:
+        name: backupdir
+        labels:
+          app: {{ template "minecraft.fullname" . }}
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          release: "{{ .Release.Name }}"
+          heritage: "{{ .Release.Service }}"
+          app.kubernetes.io/name: "{{ .Chart.Name }}"
+          app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
+          app.kubernetes.io/version: "{{ .Chart.Version }}"
+        annotations:
+        {{- with .Values.mcbackup.persistence.annotations  }}
+        {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.mcbackup.persistence.storageClass }}
+          volume.beta.kubernetes.io/storage-class: {{ .Values.mcbackup.persistence.storageClass | quote }}
+        {{- else }}
+          volume.alpha.kubernetes.io/storage-class: default
+        {{- end }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.mcbackup.persistence.backupDir.Size | quote }}
+      {{- if .Values.mcbackup.persistence.storageClass }}
+      {{- if (eq "-" .Values.mcbackup.persistence.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.mcbackup.persistence.storageClass }}"
+      {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{ end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -22,7 +22,16 @@ lifecycle:
   postStart: []
   preStop: []
 
-# upgrade strategy type (e.g. Recreate or RollingUpdate)
+# If true the workload is defined as a StatefulSet instead of a Deployment.
+# Make sure to also update the strategyType!
+# All configuration options for the Deployment (e.g. annotations) are used for the StatefulSet.
+# Regarding persistence: When an existing PVC is provided it will be shared between all Pods.
+# Otherwise the PVC configuration is used as a template to create PVCs for each replica.
+workloadAsStatefulSet: false
+
+# upgrade strategy type, depending on workload type:
+# - for Deployment sets strategy: Recreate or RollingUpdate
+# - for StatefulSet sets updateStrategy: OnDelete or RollingUpdate
 strategyType: Recreate
 
 nodeSelector: {}


### PR DESCRIPTION
Some time ago #84 proposed to have the Minecraft servers deployed as StatefulSets. Due to possible problems with servers becoming too 'sticky' the idea was discarded. As I want to use this chart in conjunction with the auto-scale-up of [mc-router](https://github.com/itzg/mc-router), I need to deploy as a StatefulSet.

This PR adds `workloadAsStatefulSet` as a flag to deploy the servers (Java/Bedrock) as Deployment or StatefulSet. When deploying as a StatefulSet with persistence enabled, a PVC template is configured using the information that would have been used to create a single PVC in case of a Deployment.