### PR TITLE
Add ipFamily-related options

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.9.4
+version: 4.9.5
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -35,6 +35,13 @@ spec:
 {{- if .Values.minecraftServer.clusterIP }}
   clusterIP: {{ .Values.minecraftServer.clusterIP }}
 {{- end }}
+{{- if .Values.minecraftServer.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.minecraftServer.ipFamilyPolicy }}
+{{- end }}
+{{- if .Values.minecraftServer.ipFamilies }}
+  ipFamilies:
+{{ toYaml .Values.minecraftServer.ipFamilies | indent 4 }}
+{{- end }}
   {{- if .Values.minecraftServer.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.minecraftServer.externalTrafficPolicy }}
   {{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -224,6 +224,8 @@ minecraftServer:
   # Set the external port of the service, usefull when using the LoadBalancer service type
   servicePort: 25565
   clusterIP:
+  ipFamilyPolicy: PreferDualStack
+  # ipFamilies: []
   loadBalancerIP:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local


### PR DESCRIPTION
Add support for ipFamilyPolicy,ipFamilies.
ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/

The actual output of yaml when values are not specified is as follows.
```
$ helm install minecraft oci://**********/library/minecraft --dry-run --debug
(omit)
---
# Source: minecraft/templates/minecraft-svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: minecraft-minecraft
  labels:
    app: minecraft-minecraft
    chart: "minecraft-4.9.4"
    release: "minecraft"
    heritage: "Helm"
    app.kubernetes.io/name: "minecraft"
    app.kubernetes.io/instance: minecraft-minecraft
    app.kubernetes.io/version: "4.9.4"
  annotations:
    {}
spec:
  type: ClusterIP
  ports:
  - name: minecraft
    port: 25565
    targetPort: minecraft
    protocol: TCP
  selector:
    app: minecraft-minecraft
```
ipFamilyPolicy,ipFamilies can be specified as follows
```
helm install minecraft oci://**********/library/minecraft --dry-run --debug --values helm/minecraft/server01.yaml
(omit)
# Source: minecraft/templates/minecraft-svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: minecraft-minecraft
  labels:
    app: minecraft-minecraft
    chart: "minecraft-4.9.4"
    release: "minecraft"
    heritage: "Helm"
    app.kubernetes.io/name: "minecraft"
    app.kubernetes.io/instance: minecraft-minecraft
    app.kubernetes.io/version: "4.9.4"
  annotations:
    {}
spec:
  type: LoadBalancer
  ipFamilyPolicy: RequireDualStack
  ipFamilies:
    - IPv4
    - IPv6
  ports:
  - name: minecraft
    port: 25565
    targetPort: minecraft
    protocol: TCP
  selector:
    app: minecraft-minecraft
```
