### PR TITLE
Add extraServiceSpec option

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.9.4
+version: 4.9.5
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -71,3 +71,6 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
+{{- if .Values.minecraftServer.extraServiceSpec }}
+{{ toYaml .Values.minecraftServer.extraServiceSpec | indent 2 }}
+{{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -238,6 +238,9 @@ minecraftServer:
   # A list of Spigot resources/plugins IDs to download.
   spigetResources: []
 
+  # Additional service specs to be defined
+  extraServiceSpec: {}
+
   # A list of Modrinth project slugs with optional version after colon
   modrinth:
     projects: []


### PR DESCRIPTION
Add a spec that is not defined as extraServiceSpec.

ref: https://github.com/itzg/minecraft-server-charts/pull/167

helm install minecraft oci://cr.i.hirano.work/library/minecraft --dry-run --debug

```yaml
# Source: minecraft/templates/minecraft-svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: minecraft-minecraft
  labels:
    app: minecraft-minecraft
    chart: "minecraft-4.9.5"
    release: "minecraft"
    heritage: "Helm"
    app.kubernetes.io/name: "minecraft"
    app.kubernetes.io/instance: minecraft-minecraft
    app.kubernetes.io/version: "4.9.5"
  annotations:
    {}
spec:
  type: ClusterIP
  ports:
  - name: minecraft
    port: 25565
    targetPort: minecraft
    protocol: TCP
  selector:
    app: minecraft-minecraft
```

cat values.yaml
```yaml
minecraftServer:
  extraServiceSpec:
    ipFamilyPolicy: RequireDualStack
```

helm install minecraft oci://cr.i.hirano.work/library/minecraft --dry-run --debug --values values.yaml
```yaml
# Source: minecraft/templates/minecraft-svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: minecraft-minecraft
  labels:
    app: minecraft-minecraft
    chart: "minecraft-4.9.5"
    release: "minecraft"
    heritage: "Helm"
    app.kubernetes.io/name: "minecraft"
    app.kubernetes.io/instance: minecraft-minecraft
    app.kubernetes.io/version: "4.9.5"
  annotations:
    {}
spec:
  type: ClusterIP
  ports:
  - name: minecraft
    port: 25565
    targetPort: minecraft
    protocol: TCP
  selector:
    app: minecraft-minecraft
  ipFamilyPolicy: RequireDualStack
```
