### PR TITLE
Added extraDeploy array

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,7 @@
 name: Lint and Test Charts
 
-on: pull_request
+on: [pull_request, workflow_dispatch]
+
 
 jobs:
   lint-test:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,6 @@
 name: Lint and Test Charts
 
-on: [pull_request, workflow_dispatch]
+on: pull_request
 
 
 jobs:

--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 2.1.0
+version: 2.1.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/_helpers.tpl
+++ b/charts/minecraft-bedrock/templates/_helpers.tpl
@@ -14,3 +14,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "extraDeploy.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}

--- a/charts/minecraft-bedrock/templates/extra-list.yaml
+++ b/charts/minecraft-bedrock/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "extraDeploy.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -71,6 +71,17 @@ extraVolumes: []
 
 ## Array of extra objects to deploy with the release
 ##
+# extraDeploy:
+#   - |
+#     apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: {{ template "minecraft.fullname" . }}-extra-cm
+#     data:
+#       key: |-
+#         {
+#           "key": "value"
+#         }
 extraDeploy: []
 
 minecraftServer:

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -69,6 +69,10 @@ initContainers: []
 #           - vers=4
 extraVolumes: []
 
+## Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
 minecraftServer:
   # This must be overridden, since we can't accept this for the user.
   eula: "FALSE"

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.9.5
+version: 4.9.6
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -38,3 +38,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
           value: {{ index . 1 | quote }}
 {{- end }}
 {{- end }}
+
+{{- define "extraDeploy.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}

--- a/charts/minecraft/templates/extra-list.yaml
+++ b/charts/minecraft/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "extraDeploy.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -109,6 +109,17 @@ extraVolumes: []
 
 ## Array of extra objects to deploy with the release
 ##
+# extraDeploy:
+#   - |
+#     apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: {{ template "minecraft.fullname" . }}-extra-cm
+#     data:
+#       key: |-
+#         {
+#           "key": "value"
+#         }
 extraDeploy: []
 
 minecraftServer:

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -106,6 +106,11 @@ sidecarContainers: []
 #           - vers=4
 extraVolumes: []
 
+
+## Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
 minecraftServer:
   # This must be overridden, since we can't accept this for the user.
   eula: "FALSE"


### PR DESCRIPTION
Adds extraDeploy array which allows us to include additional objects at deployment. My reason for this is to use helm pre-install/post-delete hooks which can automatically add/remove DNS entries for my minecraft servers.

[Reference](https://helm.sh/docs/topics/charts_hooks/#the-available-hooks)
