### PR TITLE
Added minecraftServer.serverPort value to allow the pod to run on a different port for Bedrock

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 2.2.0
+version: 2.3.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -63,6 +63,8 @@ spec:
                 - --host
                 # force health check against IPv4 port
                 - 127.0.0.1
+                - --port
+                - {{ .Values.minecraftServer.serverPort | quote }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
         livenessProbe:
           exec:
@@ -72,6 +74,8 @@ spec:
                 - --host
                 # force health check against IPv4 port
                 - 127.0.0.1
+                - --port
+                - {{ .Values.minecraftServer.serverPort | quote }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
 
       {{- with .Values.envFrom }}
@@ -127,6 +131,8 @@ spec:
           value: {{ .Values.minecraftServer.emitServerTelemetry | quote }}
         - name: ENABLE_LAN_VISIBILITY
           value: {{ .Values.minecraftServer.enableLanVisibility | quote }}
+        - name: SERVER_PORT
+          value: {{ .Values.minecraftServer.serverPort | quote }}
 
       {{- range $key, $value := .Values.extraEnv }}
       {{-   if kindIs "map" $value }}
@@ -143,7 +149,7 @@ spec:
 
         ports:
         - name: minecraft
-          containerPort: 19132
+          containerPort: {{ .Values.minecraftServer.serverPort }}
           protocol: UDP
 
         volumeMounts:

--- a/charts/minecraft-bedrock/templates/minecraft-svc.yaml
+++ b/charts/minecraft-bedrock/templates/minecraft-svc.yaml
@@ -33,7 +33,7 @@ spec:
   {{- end }}
   ports:
   - name: minecraft
-    port: 19132
+    port: {{ .Values.minecraftServer.serverPort }}
     targetPort: minecraft
     {{- if .Values.minecraftServer.nodePort }}
     nodePort: {{ .Values.minecraftServer.nodePort }}

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -153,6 +153,8 @@ minecraftServer:
   emitServerTelemetry: false
   # Enable lan visibility.
   enableLanVisibility: false
+  # IPv4 UDP port of server. If using a nodePort, set serverPort and nodePort to the same value (e.g. 30000) so ping time displays.
+  serverPort: 19132
   # type of kubernetes service to use
   serviceType: ClusterIP
   ## Set the port used if the serviceType is NodePort


### PR DESCRIPTION
The ping function doesn't work if the server is accessed on an external port (eg nodePort) that isn't 19132. This change allows the port of the pod to match the external port.