### PR TITLE
Attemp to add mc-backup rsync method to helm

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.12.0
+version: 4.13.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -96,11 +96,13 @@ spec:
 {{- template "minecraft.envMap" list "RCON_RETRY_INTERVAL" .Values.mcbackup.rconRetryInterval  }}
 {{- template "minecraft.envMap" list "EXCLUDES" .Values.mcbackup.excludes  }}
 {{- template "minecraft.envMap" list "BACKUP_METHOD" .Values.mcbackup.backupMethod  }}
-        {{- if or (eq .Values.mcbackup.backupMethod "tar") (eq .Values.mcbackup.backupMethod "rclone") }}
+        {{- if or (eq .Values.mcbackup.backupMethod "tar") (eq .Values.mcbackup.backupMethod "rclone") (eq .Values.mcbackup.backupMethod "rsync") }}
 {{- template "minecraft.envMap" list "DEST_DIR" .Values.mcbackup.destDir  }}
 {{- template "minecraft.envMap" list "LINK_LATEST" .Values.mcbackup.linkLatest  }}
+        {{- if ne .Values.mcbackup.backupMethod "rsync" }}
 {{- template "minecraft.envMap" list "TAR_COMPRESS_METHOD" .Values.mcbackup.compressMethod  }}
 {{- template "minecraft.envMap" list "ZSTD_PARAMETERS" .Values.mcbackup.zstdParameters  }}
+        {{- end }}    
         {{- if eq .Values.mcbackup.backupMethod "rclone" }}
 {{- template "minecraft.envMap" list "RCLONE_REMOTE" .Values.mcbackup.rcloneRemote  }}
 {{- template "minecraft.envMap" list "RCLONE_DEST_DIR" .Values.mcbackup.rcloneDestDir  }}

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -184,7 +184,8 @@
                     "enum": [
                         "tar",
                         "restic",
-                        "rclone"
+                        "rclone",
+                        "rsync"
                     ]
                 },
                 "resticRepository": {

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -445,7 +445,7 @@ mcbackup:
   # logs folder and cache (used by i.e. PaperMC server).
   excludes: "*.jar,cache,logs"
 
-  # backup methods, see https://github.com/itzg/docker-mc-backup e.g. tar, rclone, restic
+  # backup methods, see https://github.com/itzg/docker-mc-backup e.g. tar, rclone, restic, rsync
   backupMethod: tar
   # tar and rclone methods
   destDir: /backups


### PR DESCRIPTION
This is my WAG at adding mc-backup `rsync` support to the chart. It looks right. This is my first change to a helm chart. I'll have a few others to the proxy and perhaps support non-pvc based mounts for backup. I'm currently bypassing the chart and patching the yaml output before applying it. Would be nice to add the features to the chart and make life easier :) 