### PR TITLE
Expose ipFamilyPolicy

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 3.3.1
+version: 3.4.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/proxy-svc.yaml
+++ b/charts/minecraft-proxy/templates/proxy-svc.yaml
@@ -28,6 +28,9 @@ spec:
   {{- if .Values.minecraftProxy.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.minecraftProxy.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.minecraftProxy.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.minecraftProxy.ipFamilyPolicy }}
+  {{- end }}
   ports:
   - name: proxy
     port: 25565

--- a/charts/minecraft-proxy/templates/rcon-svc.yaml
+++ b/charts/minecraft-proxy/templates/rcon-svc.yaml
@@ -28,6 +28,9 @@ spec:
   {{- if .Values.minecraftProxy.rcon.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.minecraftProxy.rcon.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.minecraftProxy.rcon.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.minecraftProxy.rcon.ipFamilyPolicy }}
+  {{- end }}
   ports:
   - name: rcon
     port: {{ .Values.minecraftProxy.rcon.port }}

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -121,6 +121,8 @@ minecraftProxy:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local
   # externalTrafficPolicy: Cluster
+  ## Set the ipFamilyPolicy in the service to SingleStack, PreferDualStack, RequireDualStack
+  # ipFamilyPolicy: SingleStack
   externalIPs:
   # If set, this overrides the default config file path
   configFilePath: /server/config.yml
@@ -184,6 +186,8 @@ minecraftProxy:
     # loadBalancerSourceRanges: []
     ## Set the externalTrafficPolicy in the Service to either Cluster or Local
     # externalTrafficPolicy: Cluster
+    ## Set the ipFamilyPolicy in the service to SingleStack, PreferDualStack, RequireDualStack
+    # ipFamilyPolicy: SingleStack
 
   extraPorts: []
   # These options allow you to expose another port from the Minecraft proxy, plugins such


### PR DESCRIPTION
I'm running DualStack and need to expose the `ipFamilyPolicy` so I can get this to work. 

```yaml
  ## Set the ipFamilyPolicy in the service to SingleStack, PreferDualStack, RequireDualStack
  ipFamilyPolicy: SingleStack
```
