### PR TITLE
add subPath support for dataDir and backupDir

### DIFF
--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: {{ .Values.dnsPolicy}}
       {{- end }}
       {{- if .Values.dnsConfig }}
-      dnsConfig: 
+      dnsConfig:
         {{- toYaml .Values.dnsConfig | nindent 8 }}
       {{- end }}
       securityContext:
@@ -109,7 +109,7 @@ spec:
         {{- if ne .Values.mcbackup.backupMethod "rsync" }}
 {{- template "minecraft.envMap" list "TAR_COMPRESS_METHOD" .Values.mcbackup.compressMethod  }}
 {{- template "minecraft.envMap" list "ZSTD_PARAMETERS" .Values.mcbackup.zstdParameters  }}
-        {{- end }}    
+        {{- end }}
         {{- if eq .Values.mcbackup.backupMethod "rclone" }}
 {{- template "minecraft.envMap" list "RCLONE_REMOTE" .Values.mcbackup.rcloneRemote  }}
 {{- template "minecraft.envMap" list "RCLONE_DEST_DIR" .Values.mcbackup.rcloneDestDir  }}
@@ -152,8 +152,14 @@ spec:
         - name: datadir
           mountPath: /data
           readOnly: true
+        {{- if (and .Values.persistence.dataDir.enabled .Values.persistence.dataDir.subPath) }}
+          subPath: {{ .Values.persistence.dataDir.subPath }}
+        {{- end }}
         - name: backupdir
           mountPath: {{ default "/backups" .Values.mcbackup.destDir }}
+        {{- if (and .Values.mcbackup.persistence.backupDir.enabled .Values.mcbackup.persistence.backupDir.subPath) }}
+          subPath: {{ .Values.mcbackup.persistence.backupDir.subPath }}
+        {{- end }}
         {{- if or (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
         - name: rclone-config
           mountPath: /config/rclone
@@ -421,6 +427,9 @@ spec:
         - name: backupdir
           mountPath: {{ default "/backups" .Values.mcbackup.destDir }}
           readOnly: true
+          {{- if (and .Values.mcbackup.persistence.backupDir.enabled .Values.mcbackup.persistence.backupDir.subPath) }}
+          subPath: {{ .Values.mcbackup.persistence.backupDir.subPath }}
+          {{- end }}
         {{- range .Values.extraVolumes }}
         {{-   if .volumeMounts }}
         {{-     toYaml .volumeMounts | nindent 8 }}
@@ -497,7 +506,7 @@ spec:
   volumeClaimTemplates:
     {{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim) }}
     - metadata:
-        name: datadir   
+        name: datadir
         labels:
           app: {{ template "minecraft.fullname" . }}
           chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -505,7 +514,7 @@ spec:
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-          app.kubernetes.io/version: "{{ .Chart.Version }}"  
+          app.kubernetes.io/version: "{{ .Chart.Version }}"
         annotations:
         {{- with .Values.persistence.annotations  }}
         {{ toYaml . | nindent 10 }}


### PR DESCRIPTION
Adding in support for specifying a subPath of a given volume to use for backup and dataDir ( partial support was already there for dataDir )