### PR TITLE
Allow using existing secret for proxy rcon

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 3.5.0
+version: 3.6.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -118,8 +118,8 @@ spec:
         - name: RCON_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "proxy.fullname" . }}
-              key: rcon-password
+              name: {{ .Values.minecraftProxy.rcon.existingSecret | default (printf "%s-rcon" (include "proxy.fullname" .)) }}
+              key: {{ .Values.minecraftProxy.rcon.secretKey | default "rcon-password" }}
         {{- else }}
         - name: ENABLE_RCON
           value: "false"

--- a/charts/minecraft-proxy/templates/secret.yaml
+++ b/charts/minecraft-proxy/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- if not .Values.minecraftProxy.rcon.existingSecret }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +13,4 @@ type: Opaque
 data:
   rcon-password:
     {{ default "" .Values.minecraftProxy.rcon.password | b64enc | quote }}
+{{- end }}

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -181,6 +181,8 @@ minecraftProxy:
     enabled: false
     port: 25575
     password: "CHANGEME!"
+    existingSecret:
+    secretKey: rcon-password
     serviceType: LoadBalancer
     loadBalancerIP:
     # loadBalancerSourceRanges: []


### PR DESCRIPTION
TLDR: Get secret out of values.yaml into existing secret that can be out of git tree. Stole from Minecraft chart. 

I am redeploying my k3s cluster for the kids Minecraft using fluxcd so it will be quicker in the future. I found where I couldn't, that I know of, easily get the rcon secret out of the chart. I saw how it was done in the Minecraft chart and stole that and implemented it here. 