### PR TITLE
feat: allow setting annotations on mc-router services

### DIFF
--- a/charts/mc-router/Chart.yaml
+++ b/charts/mc-router/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mc-router
-version: 1.0.0
+version: 1.1.0
 appVersion: 1.20.0
 home: https://github.com/itzg/mc-router
 description: Routes Minecraft client connections to backend servers based upon the requested server address.

--- a/charts/mc-router/templates/api-service.yaml
+++ b/charts/mc-router/templates/api-service.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "mc-router.fullname" . }}-api
   labels:
     {{- include "mc-router.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.services.api.annotations | nindent 4 }}
 spec:
   {{- with .Values.services.api }}
   type: {{ .type }}

--- a/charts/mc-router/templates/router-service.yaml
+++ b/charts/mc-router/templates/router-service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "mc-router.fullname" . }}
   labels:
     {{- include "mc-router.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.services.minecraft.annotations | nindent 4 }}
 spec:
   {{- with .Values.services.minecraft }}
   type: {{ .type }}

--- a/charts/mc-router/values.yaml
+++ b/charts/mc-router/values.yaml
@@ -56,6 +56,8 @@ services:
     # port: 8080
     # # Service port exposed externally on each node
     # nodePort: 38080
+    # Service annotations
+    # annotations: {}
 
   # Service for Minecraft client connections
   minecraft:
@@ -64,6 +66,8 @@ services:
     port: 25565
     # Service port exposed externally on each node
     # nodePort: 30065
+    # Service annotations
+    # annotations: {}
 
 resources: {}
   # limits:


### PR DESCRIPTION
Allow setting annotations for the Service resources created by the `mc-router` chart in an independent fashion.

This is particularly useful when using services like MetalLB and setting either service type to LoadBalancer.
