### PR TITLE
Fix secret name for RCON password in proxy

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 3.6.0
+version: 3.6.1
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
         - name: RCON_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.minecraftProxy.rcon.existingSecret | default (printf "%s-rcon" (include "proxy.fullname" .)) }}
+              name: {{ .Values.minecraftProxy.rcon.existingSecret | default (include "proxy.fullname" .) }}
               key: {{ .Values.minecraftProxy.rcon.secretKey | default "rcon-password" }}
         {{- else }}
         - name: ENABLE_RCON

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
         - name: RCON_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.minecraftProxy.rcon.existingSecret | default (include "proxy.fullname" .) }}
+              name: {{ .Values.minecraftProxy.rcon.existingSecret | default (printf "%s-rcon" (include "proxy.fullname" .)) }}
               key: {{ .Values.minecraftProxy.rcon.secretKey | default "rcon-password" }}
         {{- else }}
         - name: ENABLE_RCON

--- a/charts/minecraft-proxy/templates/secret.yaml
+++ b/charts/minecraft-proxy/templates/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "proxy.fullname" . }}
+  name: "{{ template "proxy.fullname" . }}-rcon"
   labels:
     app: {{ template "proxy.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
Fixed secret reference name in deployment, there's no "-rcon" appended in the secret's template.