### PR TITLE
Add extraPodSpec to allow customizing Pods

### DIFF
--- a/charts/mc-router/Chart.yaml
+++ b/charts/mc-router/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mc-router
-version: 1.1.0
+version: 1.2.0
 appVersion: 1.20.0
 home: https://github.com/itzg/mc-router
 description: Routes Minecraft client connections to backend servers based upon the requested server address.

--- a/charts/mc-router/templates/deployment.yaml
+++ b/charts/mc-router/templates/deployment.yaml
@@ -164,3 +164,6 @@ spec:
         {{-   end }}
         {{- end }}
       {{- end }}
+      {{- range $key, $value := .Values.extraPodSpec }}
+      {{ $key }}: {{ tpl $value $ }}
+      {{- end }}

--- a/charts/mc-router/values.schema.json
+++ b/charts/mc-router/values.schema.json
@@ -249,6 +249,9 @@
           ]
         }
       }
+    },
+    "extraPodSpec": {
+      "type": "object"
     }
   }
 }

--- a/charts/mc-router/values.yaml
+++ b/charts/mc-router/values.yaml
@@ -114,6 +114,16 @@ extraEnv: {}
   #     fieldRef:
   #       fieldPath: status.hostIP
 
+# Extra fields to set on the pod
+#
+# Fields set here will be added to the end of the Pod spec
+# Can include any fields from https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+# that are not already set by the chart.
+#
+# The value of the field will be interpretted as a template.
+extraPodSpec: {}
+#   priorityClassName: 'my-priority-class'
+
 # Array of extra objects to deploy with the release.
 # This value is evaluated as a template
 extraDeploy: []

--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 2.6.0
+version: 2.7.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -230,6 +230,9 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
+    {{- range $key, $value := .Values.extraPodSpec }}
+      {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
   {{- if .Values.workloadAsStatefulSet }}
   volumeClaimTemplates:
     {{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim) }}

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -92,6 +92,16 @@ sidecarContainers: ""
 #           - vers=4
 extraVolumes: []
 
+# Extra fields to set on the pod
+#
+# Fields set here will be added to the end of the Pod spec
+# Can include any fields from https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+# that are not already set by the chart.
+#
+# The value of the field will be interpretted as a template.
+extraPodSpec: {}
+#   priorityClassName: 'my-priority-class'
+
 ## Array of extra objects to deploy with the release
 ##
 # extraDeploy:

--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 3.6.1
+version: 3.7.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -209,3 +209,6 @@ spec:
     {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
     {{- end }}
+    {{- range $key, $value := .Values.extraPodSpec }}
+      {{ $key }}: {{ tpl $value $ }}
+    {{- end }}

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -83,6 +83,16 @@ sidecarContainers: []
 #           - vers=4
 extraVolumes: []
 
+# Extra fields to set on the pod
+#
+# Fields set here will be added to the end of the Pod spec
+# Can include any fields from https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+# that are not already set by the chart.
+#
+# The value of the field will be interpretted as a template.
+extraPodSpec: {}
+#   priorityClassName: 'my-priority-class'
+
 minecraftProxy:
   # This can be one of "BUNGEECORD", "WATERFALL", "VELOCITY", "CUSTOM"
   type: BUNGEECORD

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.16.0
+version: 4.17.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -481,6 +481,9 @@ spec:
       {{-     toYaml .volumes | nindent 6 }}
       {{-   end }}
       {{- end }}
+      {{- range $key, $value := .Values.extraPodSpec }}
+      {{ $key }}: {{ tpl $value $ }}
+      {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -192,6 +192,9 @@
                     "type": "string"
                 }
             }
+        },
+        "extraPodSpec": {
+            "type": "object"
         }
     }
 }

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -131,6 +131,18 @@ extraVolumes: []
 #         }
 extraDeploy: []
 
+## Extra fields to set on the pod
+##
+## Fields set here will be added to the end of the Pod spec
+## Can include any fields from https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+## that are not already set by the chart.
+##
+## The value of the field will be interpretted as a template.
+##
+# extraPodSpec:
+#   priorityClassName: 'my-priority-class'
+extraPodSpec: {}
+
 minecraftServer:
   # This must be overridden, since we can't accept this for the user.
   eula: "FALSE"


### PR DESCRIPTION
Not sure how this is normally tested, so here are examples of the template output.

Fixes #204.

```
$ helm template  charts/minecraft  --set 'minecraftServer.eula=true' --set 'extraPodSpec.priorityClassName=test-priority-class' | grep 'test-priority-class' -C 10
            drop:
            - ALL
          readOnlyRootFilesystem: true
      volumes:
      - name: tmp
        emptyDir: {}
      - name: datadir
        emptyDir: {}
      - name: backupdir
        emptyDir: {}
      priorityClassName: test-priority-class
```

```
$ helm template  charts/minecraft-bedrock  --set 'minecraftServer.eula=true' --set 'extraPodSpec.priorityClassName=test-priority-class' | grep 'test-priority-class' -C 10
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          readOnlyRootFilesystem: true
      volumes:
      - name: tmp
        emptyDir: {}
      - name: datadir
        emptyDir: {}
      priorityClassName: test-priority-class
```

```
$ helm template  charts/mc-router  --set 'minecraftServer.eula=true' --set 'extraPodSpec.priorityClassName=test-priority-class' | grep 'test-priority-class' -C 70
        app.kubernetes.io/name: mc-router
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "1.20.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: release-name-mc-router
      securityContext:
        {}
      containers:
        - name: mc-router
          securityContext:
            {}
          image: "itzg/mc-router:1.20.0"
          imagePullPolicy: IfNotPresent
          env:
            - name: IN_KUBE_CLUSTER
              value: "true"
            - name: API_BINDING
              value: ":8080"
            - name: PORT
              value: "25565"
            - name: AUTO_SCALE_UP
              value: "false"
            - name: CONNECTION_RATE_LIMIT
              value: "1"
            - name: DEBUG
              value: "false"
            - name: METRICS_BACKEND
              value: "discard"
            - name: SIMPLIFY_SRV
              value: "false"
            - name: USE_PROXY_PROTOCOL
              value: "false"
            - name: VERSION
              value: "false"
          ports:
            - name: api
              containerPort: 8080
              protocol: TCP
            - name: minecraft
              containerPort: 25565
              protocol: TCP
          livenessProbe:
            initialDelaySeconds: 30
            failureThreshold: 20
            httpGet:
              path: /routes
              httpHeaders:
                - name: Accept
                  value: application/json
              port: 8080
          readinessProbe:
            initialDelaySeconds: 30
            failureThreshold: 20
            httpGet:
              path: /routes
              httpHeaders:
                - name: Accept
                  value: application/json
              port: 8080
          startupProbe:
            failureThreshold: 30
            httpGet:
              path: /routes
              httpHeaders:
                - name: Accept
                  value: application/json
              port: 8080
          resources:
            {}
      priorityClassName: test-priority-class
```

```
$ helm template  charts/minecraft-proxy  --set 'minecraftServer.eula=true' --set 'extraPodSpec.priorityClassName=test-priority-class' | grep 'test-priority-class' -C 10
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          readOnlyRootFilesystem: true
      volumes:
      - name: tmp
        emptyDir: {}
      - name: datadir
        emptyDir: {}
      priorityClassName: test-priority-class
```

```
helm template  charts/rcon-web-admin  --set 'minecraftServer.eula=true' --set 'extraPodSpec.priorityClassName=test-priority-class' --set 'rconWeb.password=testpass' --set 'service.type=LoadBalancer' | grep 'test-priority-class' -C90
        fsGroup: 2000
        runAsGroup: 3000
        runAsNonRoot: true
        runAsUser: 1000
        seccompProfile:
          type: RuntimeDefault
      volumes:
        - name: db
          emptyDir: {}
      containers:
        - name: rcon-web-admin
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
          image: "docker.io/itzg/rcon:0.14.1-1"
          imagePullPolicy: Always
          env:
            - name: RWA_USERNAME
              value: "admin"
            - name: RWA_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: release-name-rcon-web-admin
                  key: password
            - name: RWA_ADMIN
              value: "FALSE"
            - name: RWA_RCON_HOST
              value: "127.0.0.1"
            - name: RWA_RCON_PORT
              value: "25575"
            - name: RWA_GAME
              value: "minecraft"
            - name: RWA_SERVER_NAME
              value: "minecraft"
            - name: RWA_RCON_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: release-name-rcon-web-admin
                  key: rcon-password
            - name: RWA_RESTRICT_COMMANDS
              value: ""
            - name: RWA_RESTRICT_WIDGETS
              value: ""
            - name: RWA_READ_ONLY_WIDGET_OPTIONS
              value: "FALSE"
            - name: RWA_WEB_RCON
              value: "FALSE"
          command:
            - '/bin/sh'
            - '-c'
            - |-
              # Installing jq to parse k8s response
              export DEBIAN_FRONTEND=noninteractive
              apt-get -qq update >/dev/null && apt-get -qq install -y jq > /dev/null
              # Configuring k8s API auth
              APISERVER=https://kubernetes.default.svc
              SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
              NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
              TOKEN=$(cat ${SERVICEACCOUNT}/token)
              CACERT=${SERVICEACCOUNT}/ca.crt
              # Querying for websocket service
              WS_SERVICE="$(curl --silent --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/default/services/release-name-rcon-web-admin)"
              WS_IP="$(echo "$WS_SERVICE" | jq -r .status.loadBalancer.ingress[0].ip)"
              WS_PORT="4327"
              export RWA_WEBSOCKET_URL="ws://$WS_IP:$WS_PORT"
              export RWA_WEBSOCKET_URL_SSL="wss://$WS_IP:$WS_PORT"
              /usr/local/bin/node src/main.js start
          ports:
            - name: http
              containerPort: 4326
              protocol: TCP
            - name: ws
              containerPort: 4327
              protocol: TCP
          volumeMounts:
            - name: db
              mountPath: /opt/rcon-web-admin/db
          livenessProbe:
            httpGet:
              path: /
              port: http
          readinessProbe:
            httpGet:
              path: /
              port: http
          resources:
            {}
      priorityClassName: test-priority-class
```