### PR TITLE
Update NFS extraVolumes example in values.yaml

### DIFF
--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -107,12 +107,13 @@ sidecarContainers: []
 #         readOnly: true
 #     volumes:
 #       - name: nfs
-#         server: some.nfs.server.com
-#         path: /
-#         mountOptions:
-#           - port=2049
-#           - hard
-#           - vers=4
+#         nfs:
+#           server: some.nfs.server.com
+#           path: /
+#           mountOptions:
+#             - port=2049
+#             - hard
+#             - vers=4
 extraVolumes: []
 
 


### PR DESCRIPTION
The NFS volume extraVolumes example in charts/minecraft/values.yaml is missing the "nfs" key needed to define a proper NFS typed volume. Without it, the helm chart templates render an emptyDir volume instead and complain about unknown values. Adding that key renders a working NFS volume in the pod definition.

```
$ helm install my-minecraft minecraft-server-charts/minecraft --set minecraftServer.eula=true,persistence.dataDir.enabled=true --set "extraVolumes[0].volumeMounts[0].name=nfs,extraVolumes[0].volumeMounts[0].mountPath=/mnt/volume,extraVolumes[0].volumeMounts[0].readOnly=true,extraVolumes[0].volumes[0].name=nfs,extraVolumes[0].volumes[0].server=nas,extraVolumes[0].volumes[0].path=/mnt/minecraft"
W0513 22:19:06.143355   31321 warnings.go:70] unknown field "spec.template.spec.volumes[3].path"
W0513 22:19:06.143378   31321 warnings.go:70] unknown field "spec.template.spec.volumes[3].server"
NAME: my-minecraft
...

apiVersion: v1
kind: Pod
...
spec:
...
  template:
...
    spec:
      volumes:
...
        - name: nfs
          emptyDir: {}
```
=vs=
```
$ helm install my-minecraft minecraft-server-charts/minecraft --set minecraftServer.eula=true,persistence.dataDir.enabled=true --set "extraVolumes[0].volumeMounts[0].name=nfs,extraVolumes[0].volumeMounts[0].mountPath=/mnt/volume,extraVolumes[0].volumeMounts[0].readOnly=true,extraVolumes[0].volumes[0].name=nfs,extraVolumes[0].volumes[0].nfs.server=nas,extraVolumes[0].volumes[0].nfs.path=/mnt/minecraft"
NAME: my-minecraft

apiVersion: v1
kind: Pod
...
spec:
...
  template:
...
    spec:
      volumes:
...
  volumes:
...
    - name: nfs
      nfs:
        server: nas
        path: /mnt/minecraft
```