### PR TITLE
Allow configuration to mount extra volume to /data

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.18.0
+version: 4.19.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/NOTES.txt
+++ b/charts/minecraft/templates/NOTES.txt
@@ -39,7 +39,7 @@ You can watch for EXTERNAL-IP to populate by running:
 
 {{- end }}
 
-{{- if .Values.persistence.dataDir.enabled }}
+{{- if or .Values.persistence.dataDir.enabled .Values.persistence.altDataVolumeName }}
 {{- else }}
 
 ############################################################################

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -149,9 +149,14 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        {{- if .Values.persistence.altDataVolumeName }}
+        - name: {{ .Values.persistence.altDataVolumeName }}
+          mountPath: /data
+        {{- else }}
         - name: datadir
           mountPath: /data
           readOnly: true
+        {{- end }}
         - name: backupdir
           mountPath: {{ default "/backups" .Values.mcbackup.destDir }}
         {{- if or (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
@@ -413,11 +418,16 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        {{- if .Values.persistence.altDataVolumeName }}
+        - name: {{ .Values.persistence.altDataVolumeName }}
+          mountPath: /data
+        {{- else }}
         - name: datadir
           mountPath: /data
           {{- if (and .Values.persistence.dataDir.enabled .Values.persistence.dataDir.subPath) }}
           subPath: {{ .Values.persistence.dataDir.subPath }}
           {{- end }}
+        {{- end }}
         - name: backupdir
           mountPath: {{ default "/backups" .Values.mcbackup.destDir }}
           readOnly: true

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -399,6 +399,8 @@ envFrom: []
 persistence:
   labels: {}
   annotations: {}
+  ## specify an alternative volume to be mounted to /data instead of datadir.
+  # altDataVolumeName: ""
   ## minecraft data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
I have an NFS share that contains the contents of my Minecraft server and would like to use it as the volume that gets mounted to `/data` directory in the container. As far as I can tell, it is not possible to configure the Minecraft Helm chart in this manner because an `emptyDir` volume is always mounted when the PVC is disabled and thus a conflict occurs.

To allow any defined extra volume to be mounted to the /data directory, I propose a new `extraDataVolume` configuration be introduced.

Thanks in advance for taking a look.

Example use with NFS:
```
persistence:
  extraDataVolume: nfs

extraVolumes:
    volumes:
      - name: nfs
        nfs:
          server: example.nfs.server
          path: /data/minecraft
```
