### PR TITLE
Fix: Make rclone config folder writable

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.19.0
+version: 4.20.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -441,6 +441,17 @@ spec:
       {{- if .Values.sidecarContainers }}
       {{- toYaml .Values.sidecarContainers | nindent 6 }}
       {{- end }}
+      {{- if or (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
+      initContainers:
+        - name: init-container
+          image: busybox
+          command: ['sh', '-c', 'cp /secret/rclone.conf /config/rclone/']
+          volumeMounts:
+          - name: rclone-secret
+            mountPath: /secret
+          - name: rclone-config
+            mountPath: /config/rclone
+      {{- end }}
       volumes:
       - name: tmp
         emptyDir: {}
@@ -475,7 +486,7 @@ spec:
         emptyDir: {}
       {{- end }}
       {{- if or (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
-      - name: rclone-config
+      - name: rclone-secret
         secret:
         {{- if .Values.mcbackup.rcloneConfigExistingSecret }}
           secretName: {{ .Values.mcbackup.rcloneConfigExistingSecret }}
@@ -485,6 +496,8 @@ spec:
           items:
           - key: rclone.conf
             path: rclone.conf
+      - name: rclone-config
+        emptyDir: {}
       {{- end }}
       {{- range .Values.extraVolumes }}
       {{-   if .volumes }}


### PR DESCRIPTION
# Description

Since Kubernetes will make Secrets volume to be mounted as read-only, when mc-backup is trying to run `mkdir` in [this line](https://github.com/itzg/docker-mc-backup/blob/aea603f867e3aab2bb0165d7db93d595c6966ccb/scripts/opt/backup-loop.sh#L305), our pod will show the following error:

```
2024-06-22T00:59:20+0800 INFO sleeping 24h...
2024/06/22 00:59:24 ERROR : Failed to save config after 10 tries: failed to create temp file for new config: open /config/rclone/rclone.conf59648627: read-only file system
```

To fix this issue, we can create a new empty volume and use InitContainer to copy the content of the Secrets volume to the new volume. Then we can mount the new volume as read-write in the main container.

# Proven Image

I've tested this on my environment and now my `mc-backup` pod can successfully upload the backup to my drive using `rclone`.

<img width="1195" alt="image" src="https://github.com/itzg/minecraft-server-charts/assets/40032648/76a3e7c9-a8bb-487c-b7fe-f1dade2f33b6">




