### PR TITLE
mc-router: Add extraServiceSpec for customizing services

### DIFF
--- a/charts/mc-router/Chart.yaml
+++ b/charts/mc-router/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mc-router
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.20.0
 home: https://github.com/itzg/mc-router
 description: Routes Minecraft client connections to backend servers based upon the requested server address.

--- a/charts/mc-router/templates/router-service.yaml
+++ b/charts/mc-router/templates/router-service.yaml
@@ -22,3 +22,6 @@ spec:
   {{- end }}
   selector:
     {{- include "mc-router.selectorLabels" . | nindent 4 }}
+  {{- if .Values.services.extraServiceSpec }}
+  {{ toYaml .Values.services.extraServiceSpec | indent 4 }}
+  {{- end }}

--- a/charts/mc-router/values.yaml
+++ b/charts/mc-router/values.yaml
@@ -69,6 +69,11 @@ services:
     # Service annotations
     # annotations: {}
 
+  # Additional service specs to be defined
+  # Fields set here will be added to the end of the Service spec
+  # Can include any fields from https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
+  extraServiceSpec: {}
+
 resources: {}
   # limits:
   #   cpu: 250m


### PR DESCRIPTION
This pull request adds the `extraServiceSpec` field inside the `service` object in the values.yaml
Allows for more flexibility on the user end
Closes #215 