### PR TITLE
Fix: mc-router extraServiceSpec wrong indentation

### DIFF
--- a/charts/mc-router/Chart.yaml
+++ b/charts/mc-router/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mc-router
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.20.0
 home: https://github.com/itzg/mc-router
 description: Routes Minecraft client connections to backend servers based upon the requested server address.

--- a/charts/mc-router/templates/router-service.yaml
+++ b/charts/mc-router/templates/router-service.yaml
@@ -23,5 +23,5 @@ spec:
   selector:
     {{- include "mc-router.selectorLabels" . | nindent 4 }}
   {{- if .Values.services.extraServiceSpec }}
-  {{ toYaml .Values.services.extraServiceSpec | indent 4 }}
+  {{ toYaml .Values.services.extraServiceSpec | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
Closes #217 

Tested locally with the following values
```
services:
  extraServiceSpec:
    ipFamilies:
      - IPv4
      - IPv6
    ipFamilyPolicy: PreferDualStack
```

```
> helm install -f values.yaml minecraft-server-charts-master/charts/mc-router/ --generate-name
creating 5 resource(s)
NAME: mc-router-1722869570
LAST DEPLOYED: Mon Aug  5 14:52:50 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

Output
![image](https://github.com/user-attachments/assets/a7874a71-f232-473b-88b5-3000a09ab27f)

Additional testing can be done before merge if deemed required
