### PR TITLE
Allow optional definition of ingress

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.20.0
+version: 4.20.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.20.1
+version: 4.21.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/extraports-ing.yaml
+++ b/charts/minecraft/templates/extraports-ing.yaml
@@ -1,6 +1,6 @@
 {{- $minecraftFullname := include "minecraft.fullname" . }}
 {{- range .Values.minecraftServer.extraPorts }}
-{{- if default "" .ingress.enabled }}
+{{- if default "" (.ingress).enabled }}
 {{- $servicePort := .service.port }}
 {{- $serviceName := printf "%s-%s" $minecraftFullname .name }}
 ---


### PR DESCRIPTION
Removes the requirement of setting `ingress.enabled: false` for extraPorts. For example, an item in `extraPorts[]` needing no ingress currently requires:

```yaml
extraPorts:
  - name: map
    protocol: TCP
    ingress:
      enabled: false
    ...
```

If `ingress` is omitted, the following error is thrown:

```text
Error: template: minecraft-toiletbowl/charts/minecraft/templates/extraports-ing.yaml:3:26: executing "minecraft-toiletbowl/charts/minecraft/templates/extraports-ing.yaml" at <.ingress.enabled>: nil pointer evaluating interface {}.enabled
```


With this update, we can safely omit the `ingress` object entirely:

```yaml
extraPorts:
  - name: map
    protocol: TCP
    ...
```