### PR TITLE
Config refactor

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.22.0
+version: 4.22.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.21.0
+version: 4.22.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -25,17 +25,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end }}
 {{- end -}}
 
-{{- define "minecraft.envMap" }}
-{{- if index . 1 }}
-        - name: {{ index . 0 }}
-          value: {{ index . 1 | quote }}
+{{- define "minecraft.extraEnv" }}
+{{- range $key, $value := . }}
+{{- if kindIs "map" $value }}
+{{-   if hasKey $value "valueFrom" }}
+- name: {{ $key }}
+  valueFrom:
+    {{- $value.valueFrom | toYaml | nindent 4 }}
+{{-   end }}
+{{- else }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
 {{- end }}
-{{- end }}
-
-{{- define "minecraft.envBoolMap" }}
-{{- if ne (toString (index . 1)) "default" }}
-        - name: {{ index . 0 }}
-          value: {{ index . 1 | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/minecraft/templates/config-backup.yaml
+++ b/charts/minecraft/templates/config-backup.yaml
@@ -1,0 +1,38 @@
+{{ with .Values.minecraftServer }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "minecraft.fullname" . }}-backup-config
+data:
+  SRC_DIR: "/data"
+  BACKUP_NAME: {{ .Values.minecraftServer.worldSaveName }}
+  INITIAL_DELAY: {{ .Values.mcbackup.initialDelay }}
+  BACKUP_INTERVAL: {{ .Values.mcbackup.backupInterval }}
+  PRUNE_BACKUPS_DAYS: {{ .Values.mcbackup.pruneBackupsDays }}
+  PAUSE_IF_NO_PLAYERS: {{ .Values.mcbackup.pauseIfNoPlayers }}
+  SERVER_PORT: "25565"
+  RCON_HOST: "localhost"
+  RCON_PORT: {{ .Values.minecraftServer.rcon.port }}
+  RCON_RETRIES: {{ .Values.mcbackup.rconRetries }}
+  RCON_RETRY_INTERVAL: {{ .Values.mcbackup.rconRetryInterval }}
+  EXCLUDES: {{ .Values.mcbackup.excludes }}
+  BACKUP_METHOD: {{ .Values.mcbackup.backupMethod }}
+  {{- if or (eq .Values.mcbackup.backupMethod "tar") (eq .Values.mcbackup.backupMethod "rclone") (eq .Values.mcbackup.backupMethod "rsync") }}
+  DEST_DIR: {{ .Values.mcbackup.destDir }}
+  LINK_LATEST: {{ .Values.mcbackup.linkLatest }}
+  {{-   if ne .Values.mcbackup.backupMethod "rsync" }}
+  TAR_COMPRESS_METHOD: {{ .Values.mcbackup.compressMethod }}
+  ZSTD_PARAMETERS: {{ .Values.mcbackup.zstdParameters }}
+  {{-   end }}
+  {{-   if eq .Values.mcbackup.backupMethod "rclone" }}
+  RCLONE_REMOTE: {{ .Values.mcbackup.rcloneRemote }}
+  RCLONE_DEST_DIR: {{ .Values.mcbackup.rcloneDestDir }}
+  RCLONE_COMPRESS_METHOD: {{ .Values.mcbackup.rcloneCompressMethod }}
+  {{-   end }}
+  {{- end }}
+  {{- if eq .Values.mcbackup.backupMethod "restic" }}
+  RESTIC_REPOSITORY: {{ .Values.mcbackup.resticRepository }}
+  RESTIC_ADDITIONAL_TAGS: {{ .Values.mcbackup.resticAdditionalTags }}
+  PRUNE_RESTIC_RETENTION: {{ .Values.mcbackup.pruneResticRetention }}
+  {{- end }}
+{{- end }}

--- a/charts/minecraft/templates/config-server.yaml
+++ b/charts/minecraft/templates/config-server.yaml
@@ -1,0 +1,85 @@
+{{ with .Values.minecraftServer }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "minecraft.fullname" . }}-config
+data:
+  EULA: {{ .eula }}
+  TYPE: {{ .type }}
+  FORGE_INSTALLER_URL: {{ .forgeInstallerUrl }}
+  FORGEVERSION: {{ .forgeVersion }}
+  SPIGOT_DOWNLOAD_URL: {{ .spigotDownloadUrl }}
+  BUKKIT_DOWNLOAD_URL: {{ .bukkitDownloadUrl }}
+  PAPER_DOWNLOAD_URL: {{ .paperDownloadUrl }}
+  {{- if eq .type "FTBA" }}
+  FTB_MODPACK_ID: {{ required "You must supply a minecraftserver.ftbModpackVersionID with type=FTBA" .ftbModpackId }}
+  {{- end }}
+  FTB_MODPACK_VERSION_ID: {{ .ftbModpackVersionId }}
+  CF_SERVER_MOD: {{ .cfServerMod }}
+  FTB_LEGACYJAVAFIXER: {{ .ftbLegacyJavaFixer }}
+  VERSION: {{ .version }}
+  DIFFICULTY: {{ .difficulty }}
+  WHITELIST: {{ .whitelist }}
+  OPS: {{ .ops }}
+  ICON: {{ .icon }}
+  MAX_PLAYERS: {{ .maxPlayers }}
+  MAX_WORLD_SIZE: {{ .maxWorldSize }}
+  ALLOW_NETHER: {{ .allowNether }}
+  ANNOUNCE_PLAYER_ACHIEVEMENTS: {{ .announcePlayerAchievements }}
+  ENABLE_COMMAND_BLOCK: {{ .enableCommandBlock }}
+  FORCE_GAMEMODE: {{ .forcegameMode }}
+  FORCE_REDOWNLOAD: {{ .forceReDownload }}
+  GENERATE_STRUCTURES: {{ .generateStructures }}
+  HARDCORE: {{ .hardcore }}
+  MAX_BUILD_HEIGHT: {{ .maxBuildHeight }}
+  MAX_TICK_TIME: {{ .maxTickTime }}
+  SPAWN_ANIMALS: {{ .spawnAnimals }}
+  SPAWN_MONSTERS: {{ .spawnMonsters }}
+  SPAWN_NPCS: {{ .spawnNPCs }}
+  SPAWN_PROTECTION: {{ .spawnProtection }}
+  VIEW_DISTANCE: {{ .viewDistance }}
+  SEED: {{ .levelSeed }}
+  MODE: {{ .gameMode }}
+  MOTD: {{ .motd }}
+  PVP: {{ .pvp }}
+  LEVEL_TYPE: {{ .levelType }}
+  GENERATOR_SETTINGS: {{ .generatorSettings }}
+  LEVEL: {{ .worldSaveName }}
+  WORLD: {{ .downloadWorldUrl }}
+  MODPACK: {{ .downloadModpackUrl }}
+  REMOVE_OLD_MODS: {{ .removeOldMods }}
+  MODS: {{ join "," .modUrls }}
+  PLUGINS: {{ join "," .pluginUrls }}
+  SPIGET_RESOURCES: {{ join "," .spigetResources }}
+  {{- with .modrinth }}
+  MODRINTH_PROJECTS: {{ join "," .projects }}
+  MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES: {{ .optionalDependencies }} # TODO: Deprecated in favor of MODRINTH_DOWNLOAD_DEPENDENCIES
+  MODRINTH_ALLOWED_VERSION_TYPE: {{ .allowedVersionType }}
+  {{- end }}
+  VANILLATWEAKS_SHARECODE: {{ join "," .vanillaTweaksShareCodes }}
+  RESOURCE_PACK_ENFORCE: {{ .resourcePackEnforce }}
+  RESOURCE_PACK: {{ .resourcePackUrl }}
+  RESOURCE_PACK_SHA1: {{ .resourcePackSha }}
+  ONLINE_MODE: {{ .onlineMode }}
+  ENFORCE_SECURE_PROFILE: {{ .enforceSecureProfile }}
+  MEMORY: {{ .memory }}
+  JVM_OPTS: {{ .jvmOpts }}
+  JVM_XX_OPTS: {{ .jvmXXOpts }}
+  OVERRIDE_SERVER_PROPERTIES: {{ .overrideServerProperties }}
+  ENABLE_RCON: {{ .rcon.enabled }}
+  ENABLE_QUERY: {{ .query.enabled }}
+  QUERY_PORT: {{ .query.port }}
+  {{- with .autoCurseForge }}
+  CF_PAGE_URL: {{ .pageUrl }}
+  CF_SLUG: {{ .slug }}
+  CF_FILE_ID: {{ .fileId }}
+  CF_FILENAME_MATCHER: {{ .filenameMatcher }}
+  CF_EXCLUDE_MODS: {{ join "," .excludeMods }}
+  CF_FORCE_INCLUDE_MODS: {{ join "," .includeMods }}
+  CF_EXCLUDE_INCLUDE_FILE: {{ .excludeIncludeFile }}
+  CF_FORCE_SYNCHRONIZE: {{ .forceSynchronize }}
+  CF_SET_LEVEL_FROM: {{ .setLevelFrom }}
+  CF_PARALLEL_DOWNLOADS: {{ .parallelDownloads }}
+  CF_OVERRIDES_SKIP_EXISTING: "true"
+  {{- end }}
+{{- end }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -47,11 +47,12 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
+      {{- if .Values.podAnnotations }}
       annotations:
-        kubectl.kubernetes.io/default-container: {{ template "minecraft.fullname" . }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+      {{- end }}
     spec:
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
@@ -71,105 +72,6 @@ spec:
       {{- toYaml .Values.initContainers | nindent 8 }}
       {{- end }}
       containers:
-      {{- if and .Values.mcbackup.enabled .Values.minecraftServer.rcon.enabled }}
-      - name: {{ template "minecraft.fullname" . }}-mc-backup
-        image: "{{ .Values.mcbackup.image.repository }}:{{ .Values.mcbackup.image.tag }}"
-        imagePullPolicy: {{ .Values.mcbackup.image.pullPolicy }}
-        resources:
-{{ toYaml .Values.mcbackup.resources | indent 10 }}
-      {{- with .Values.mcbackup.envFrom }}
-        envFrom:
-          {{- . | toYaml | nindent 10 }}{{ end }}
-        env:
-        - name: SRC_DIR
-          value: "/data"
-{{- template "minecraft.envMap" list "BACKUP_NAME" .Values.minecraftServer.worldSaveName  }}
-{{- template "minecraft.envMap" list "INITIAL_DELAY" .Values.mcbackup.initialDelay  }}
-{{- template "minecraft.envMap" list "BACKUP_INTERVAL" .Values.mcbackup.backupInterval  }}
-{{- template "minecraft.envMap" list "PRUNE_BACKUPS_DAYS" .Values.mcbackup.pruneBackupsDays  }}
-{{- template "minecraft.envMap" list "PAUSE_IF_NO_PLAYERS" .Values.mcbackup.pauseIfNoPlayers  }}
-        - name: SERVER_PORT
-          value: "25565"
-        - name: RCON_HOST
-          value: "localhost"
-{{- template "minecraft.envMap" list "RCON_PORT" .Values.minecraftServer.rcon.port  }}
-        - name: RCON_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.minecraftServer.rcon.existingSecret | default (printf "%s-rcon" (include "minecraft.fullname" .)) }}
-              key: {{ .Values.minecraftServer.rcon.secretKey | default "rcon-password" }}
-{{- template "minecraft.envMap" list "RCON_RETRIES" .Values.mcbackup.rconRetries  }}
-{{- template "minecraft.envMap" list "RCON_RETRY_INTERVAL" .Values.mcbackup.rconRetryInterval  }}
-{{- template "minecraft.envMap" list "EXCLUDES" .Values.mcbackup.excludes  }}
-{{- template "minecraft.envMap" list "BACKUP_METHOD" .Values.mcbackup.backupMethod  }}
-        {{- if or (eq .Values.mcbackup.backupMethod "tar") (eq .Values.mcbackup.backupMethod "rclone") (eq .Values.mcbackup.backupMethod "rsync") }}
-{{- template "minecraft.envMap" list "DEST_DIR" .Values.mcbackup.destDir  }}
-{{- template "minecraft.envMap" list "LINK_LATEST" .Values.mcbackup.linkLatest  }}
-        {{- if ne .Values.mcbackup.backupMethod "rsync" }}
-{{- template "minecraft.envMap" list "TAR_COMPRESS_METHOD" .Values.mcbackup.compressMethod  }}
-{{- template "minecraft.envMap" list "ZSTD_PARAMETERS" .Values.mcbackup.zstdParameters  }}
-        {{- end }}
-        {{- if eq .Values.mcbackup.backupMethod "rclone" }}
-{{- template "minecraft.envMap" list "RCLONE_REMOTE" .Values.mcbackup.rcloneRemote  }}
-{{- template "minecraft.envMap" list "RCLONE_DEST_DIR" .Values.mcbackup.rcloneDestDir  }}
-{{- template "minecraft.envMap" list "RCLONE_COMPRESS_METHOD" .Values.mcbackup.rcloneCompressMethod  }}
-        {{- end }}
-        {{- end }}
-        {{- if eq .Values.mcbackup.backupMethod "restic" }}
-{{- template "minecraft.envMap" list "RESTIC_REPOSITORY" .Values.mcbackup.resticRepository  }}
-{{- template "minecraft.envMap" list "RESTIC_ADDITIONAL_TAGS" .Values.mcbackup.resticAdditionalTags  }}
-{{- template "minecraft.envMap" list "PRUNE_RESTIC_RETENTION" .Values.mcbackup.pruneResticRetention  }}
-        {{-   range $key, $value := .Values.mcbackup.resticEnvs }}
-        {{-     if kindIs "map" $value }}
-        {{-       if hasKey $value "valueFrom" }}
-        - name: {{ $key }}
-          valueFrom:
-            {{- $value.valueFrom | toYaml | nindent 12 }}
-        {{-       end }}
-        {{-     else }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{-     end }}
-        {{-   end }}
-        {{- end }}
-
-        {{- range $key, $value := .Values.mcbackup.extraEnv }}
-        {{-   if kindIs "map" $value }}
-        {{-     if hasKey $value "valueFrom" }}
-        - name: {{ $key }}
-          valueFrom:
-            {{- $value.valueFrom | toYaml | nindent 12 }}
-        {{-     end }}
-        {{-   else }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{-   end }}
-        {{- end }}
-        volumeMounts:
-        - name: tmp
-          mountPath: /tmp
-        {{- if .Values.persistence.altDataVolumeName }}
-        - name: {{ .Values.persistence.altDataVolumeName }}
-          mountPath: /data
-        {{- else }}
-        - name: datadir
-          mountPath: /data
-          readOnly: true
-        {{- end }}
-        - name: backupdir
-          mountPath: {{ default "/backups" .Values.mcbackup.destDir }}
-        {{- if or (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
-        - name: rclone-config
-          mountPath: /config/rclone
-        {{- end }}
-        {{- range .Values.extraVolumes }}
-        {{-   if .volumeMounts }}
-        {{-     toYaml .volumeMounts | nindent 8 }}
-        {{-   end }}
-        {{- end }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
-      {{- end }}
       - name: {{ template "minecraft.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -437,6 +339,105 @@ spec:
         {{- end }}
         securityContext:
             {{- toYaml .Values.securityContext | nindent 10 }}
+      {{- if and .Values.mcbackup.enabled .Values.minecraftServer.rcon.enabled }}
+      - name: {{ template "minecraft.fullname" . }}-mc-backup
+        image: "{{ .Values.mcbackup.image.repository }}:{{ .Values.mcbackup.image.tag }}"
+        imagePullPolicy: {{ .Values.mcbackup.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.mcbackup.resources | indent 10 }}
+      {{- with .Values.mcbackup.envFrom }}
+        envFrom:
+          {{- . | toYaml | nindent 10 }}{{ end }}
+        env:
+        - name: SRC_DIR
+          value: "/data"
+{{- template "minecraft.envMap" list "BACKUP_NAME" .Values.minecraftServer.worldSaveName  }}
+{{- template "minecraft.envMap" list "INITIAL_DELAY" .Values.mcbackup.initialDelay  }}
+{{- template "minecraft.envMap" list "BACKUP_INTERVAL" .Values.mcbackup.backupInterval  }}
+{{- template "minecraft.envMap" list "PRUNE_BACKUPS_DAYS" .Values.mcbackup.pruneBackupsDays  }}
+{{- template "minecraft.envMap" list "PAUSE_IF_NO_PLAYERS" .Values.mcbackup.pauseIfNoPlayers  }}
+        - name: SERVER_PORT
+          value: "25565"
+        - name: RCON_HOST
+          value: "localhost"
+{{- template "minecraft.envMap" list "RCON_PORT" .Values.minecraftServer.rcon.port  }}
+        - name: RCON_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.minecraftServer.rcon.existingSecret | default (printf "%s-rcon" (include "minecraft.fullname" .)) }}
+              key: {{ .Values.minecraftServer.rcon.secretKey | default "rcon-password" }}
+{{- template "minecraft.envMap" list "RCON_RETRIES" .Values.mcbackup.rconRetries  }}
+{{- template "minecraft.envMap" list "RCON_RETRY_INTERVAL" .Values.mcbackup.rconRetryInterval  }}
+{{- template "minecraft.envMap" list "EXCLUDES" .Values.mcbackup.excludes  }}
+{{- template "minecraft.envMap" list "BACKUP_METHOD" .Values.mcbackup.backupMethod  }}
+        {{- if or (eq .Values.mcbackup.backupMethod "tar") (eq .Values.mcbackup.backupMethod "rclone") (eq .Values.mcbackup.backupMethod "rsync") }}
+{{- template "minecraft.envMap" list "DEST_DIR" .Values.mcbackup.destDir  }}
+{{- template "minecraft.envMap" list "LINK_LATEST" .Values.mcbackup.linkLatest  }}
+        {{- if ne .Values.mcbackup.backupMethod "rsync" }}
+{{- template "minecraft.envMap" list "TAR_COMPRESS_METHOD" .Values.mcbackup.compressMethod  }}
+{{- template "minecraft.envMap" list "ZSTD_PARAMETERS" .Values.mcbackup.zstdParameters  }}
+        {{- end }}
+        {{- if eq .Values.mcbackup.backupMethod "rclone" }}
+{{- template "minecraft.envMap" list "RCLONE_REMOTE" .Values.mcbackup.rcloneRemote  }}
+{{- template "minecraft.envMap" list "RCLONE_DEST_DIR" .Values.mcbackup.rcloneDestDir  }}
+{{- template "minecraft.envMap" list "RCLONE_COMPRESS_METHOD" .Values.mcbackup.rcloneCompressMethod  }}
+        {{- end }}
+        {{- end }}
+        {{- if eq .Values.mcbackup.backupMethod "restic" }}
+{{- template "minecraft.envMap" list "RESTIC_REPOSITORY" .Values.mcbackup.resticRepository  }}
+{{- template "minecraft.envMap" list "RESTIC_ADDITIONAL_TAGS" .Values.mcbackup.resticAdditionalTags  }}
+{{- template "minecraft.envMap" list "PRUNE_RESTIC_RETENTION" .Values.mcbackup.pruneResticRetention  }}
+        {{-   range $key, $value := .Values.mcbackup.resticEnvs }}
+        {{-     if kindIs "map" $value }}
+        {{-       if hasKey $value "valueFrom" }}
+        - name: {{ $key }}
+          valueFrom:
+            {{- $value.valueFrom | toYaml | nindent 12 }}
+        {{-       end }}
+        {{-     else }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{-     end }}
+        {{-   end }}
+        {{- end }}
+
+        {{- range $key, $value := .Values.mcbackup.extraEnv }}
+        {{-   if kindIs "map" $value }}
+        {{-     if hasKey $value "valueFrom" }}
+        - name: {{ $key }}
+          valueFrom:
+            {{- $value.valueFrom | toYaml | nindent 12 }}
+        {{-     end }}
+        {{-   else }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{-   end }}
+        {{- end }}
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        {{- if .Values.persistence.altDataVolumeName }}
+        - name: {{ .Values.persistence.altDataVolumeName }}
+          mountPath: /data
+        {{- else }}
+        - name: datadir
+          mountPath: /data
+          readOnly: true
+        {{- end }}
+        - name: backupdir
+          mountPath: {{ default "/backups" .Values.mcbackup.destDir }}
+        {{- if or (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
+        - name: rclone-config
+          mountPath: /config/rclone
+        {{- end }}
+        {{- range .Values.extraVolumes }}
+        {{-   if .volumeMounts }}
+        {{-     toYaml .volumeMounts | nindent 8 }}
+        {{-   end }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+      {{- end }}
       {{- if .Values.sidecarContainers }}
       {{- toYaml .Values.sidecarContainers | nindent 6 }}
       {{- end }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -133,7 +133,6 @@ spec:
               optional: false
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- end }}
         env:
         {{- with .Values.minecraftServer.rcon }}
         {{- if and .enabled (not .withGeneratedPassword) }} # TODO: Validate functionality
@@ -313,7 +312,7 @@ spec:
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.nodeSelector |n indent 8 }}
+        {{ toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity:

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
       {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
+        checksum/config-backup: {{ include (print $.Template.BasePath "/config-backup.yaml") . | sha256sum }}
+        checksum/config-server: {{ include (print $.Template.BasePath "/config-server.yaml") . | sha256sum }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -47,12 +47,11 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
-      {{- if .Values.podAnnotations }}
       annotations:
+        kubectl.kubernetes.io/default-container: {{ template "minecraft.fullname" . }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-      {{- end }}
     spec:
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
@@ -62,7 +61,7 @@ spec:
       dnsPolicy: {{ .Values.dnsPolicy}}
       {{- end }}
       {{- if .Values.dnsConfig }}
-      dnsConfig: 
+      dnsConfig:
         {{- toYaml .Values.dnsConfig | nindent 8 }}
       {{- end }}
       securityContext:
@@ -109,7 +108,7 @@ spec:
         {{- if ne .Values.mcbackup.backupMethod "rsync" }}
 {{- template "minecraft.envMap" list "TAR_COMPRESS_METHOD" .Values.mcbackup.compressMethod  }}
 {{- template "minecraft.envMap" list "ZSTD_PARAMETERS" .Values.mcbackup.zstdParameters  }}
-        {{- end }}    
+        {{- end }}
         {{- if eq .Values.mcbackup.backupMethod "rclone" }}
 {{- template "minecraft.envMap" list "RCLONE_REMOTE" .Values.mcbackup.rcloneRemote  }}
 {{- template "minecraft.envMap" list "RCLONE_DEST_DIR" .Values.mcbackup.rcloneDestDir  }}
@@ -523,7 +522,7 @@ spec:
   volumeClaimTemplates:
     {{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim) }}
     - metadata:
-        name: datadir   
+        name: datadir
         labels:
           app: {{ template "minecraft.fullname" . }}
           chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -531,7 +530,7 @@ spec:
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-          app.kubernetes.io/version: "{{ .Chart.Version }}"  
+          app.kubernetes.io/version: "{{ .Chart.Version }}"
         annotations:
         {{- with .Values.persistence.annotations  }}
         {{ toYaml . | nindent 10 }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -122,180 +122,31 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-      {{- with .Values.envFrom }}
+        {{- with .Values.envFrom }}
         envFrom:
+          - configMapRef:
+              name: {{ template "minecraft.fullname" . }}-config
+              optional: false
           {{- . | toYaml | nindent 10 }}{{ end }}
+        {{- end }}
         env:
-{{- template "minecraft.envMap" list "EULA" .Values.minecraftServer.eula  }}
-{{- template "minecraft.envMap" list "TYPE" .Values.minecraftServer.type  }}
-        {{- if eq .Values.minecraftServer.type "FORGE" }}
-        {{- if .Values.minecraftServer.forgeInstallerUrl }}
-{{- template "minecraft.envMap" list "FORGE_INSTALLER_URL" .Values.minecraftServer.forgeInstallerUrl  }}
-        {{- else }}
-{{- template "minecraft.envMap" list "FORGEVERSION" .Values.minecraftServer.forgeVersion  }}
-        {{- end }}
-        {{- else if eq .Values.minecraftServer.type "SPIGOT" }}
-{{- template "minecraft.envMap" list "SPIGOT_DOWNLOAD_URL" .Values.minecraftServer.spigotDownloadUrl  }}
-        {{- else if eq .Values.minecraftServer.type "BUKKIT" }}
-{{- template "minecraft.envMap" list "BUKKIT_DOWNLOAD_URL" .Values.minecraftServer.bukkitDownloadUrl  }}
-        {{- else if eq .Values.minecraftServer.type "PAPER" }}
-{{- template "minecraft.envMap" list "PAPER_DOWNLOAD_URL" .Values.minecraftServer.paperDownloadUrl  }}
-        {{- else if eq .Values.minecraftServer.type "FTBA" }}
-{{- template "minecraft.envMap" list "FTB_MODPACK_ID" (required "You must supply a minecraftserver.ftbModpackVersionID with type=FTBA" .Values.minecraftServer.ftbModpackId)  }}
-        {{- if .Values.minecraftServer.ftbModpackVersionId }}
-{{- template "minecraft.envMap" list "FTB_MODPACK_VERSION_ID" .Values.minecraftServer.ftbModpackVersionId  }}
-        {{- end }}
-        {{- else if eq .Values.minecraftServer.type "CURSEFORGE" }}
-{{- template "minecraft.envMap" list "CF_SERVER_MOD" .Values.minecraftServer.cfServerMod  }}
-{{- template "minecraft.envBoolMap" list "FTB_LEGACYJAVAFIXER" .Values.minecraftServer.ftbLegacyJavaFixer  }}
-        {{- end }}
-{{- template "minecraft.envMap" list "VERSION" .Values.minecraftServer.version  }}
-{{- template "minecraft.envMap" list "DIFFICULTY" .Values.minecraftServer.difficulty  }}
-{{- template "minecraft.envMap" list "WHITELIST" .Values.minecraftServer.whitelist }}
-{{- template "minecraft.envMap" list "OPS" .Values.minecraftServer.ops  }}
-{{- template "minecraft.envMap" list "ICON" .Values.minecraftServer.icon  }}
-{{- template "minecraft.envMap" list "MAX_PLAYERS" .Values.minecraftServer.maxPlayers  }}
-{{- template "minecraft.envMap" list "MAX_WORLD_SIZE" .Values.minecraftServer.maxWorldSize  }}
-{{- template "minecraft.envBoolMap" list "ALLOW_NETHER" .Values.minecraftServer.allowNether  }}
-{{- template "minecraft.envBoolMap" list "ANNOUNCE_PLAYER_ACHIEVEMENTS" .Values.minecraftServer.announcePlayerAchievements  }}
-{{- template "minecraft.envBoolMap" list "ENABLE_COMMAND_BLOCK" .Values.minecraftServer.enableCommandBlock  }}
-{{- template "minecraft.envBoolMap" list "FORCE_GAMEMODE" .Values.minecraftServer.forcegameMode  }}
-        {{- if .Values.minecraftServer.forceReDownload }}
-        - name: FORCE_REDOWNLOAD
-          value: "TRUE"
-        {{- end }}
-{{- template "minecraft.envBoolMap" list "GENERATE_STRUCTURES" .Values.minecraftServer.generateStructures  }}
-{{- template "minecraft.envBoolMap" list "HARDCORE" .Values.minecraftServer.hardcore  }}
-{{- template "minecraft.envMap" list "MAX_BUILD_HEIGHT" .Values.minecraftServer.maxBuildHeight  }}
-{{- template "minecraft.envMap" list "MAX_TICK_TIME" .Values.minecraftServer.maxTickTime  }}
-{{- template "minecraft.envBoolMap" list "SPAWN_ANIMALS" .Values.minecraftServer.spawnAnimals  }}
-{{- template "minecraft.envBoolMap" list "SPAWN_MONSTERS" .Values.minecraftServer.spawnMonsters  }}
-{{- template "minecraft.envBoolMap" list "SPAWN_NPCS" .Values.minecraftServer.spawnNPCs  }}
-{{- template "minecraft.envMap" list "SPAWN_PROTECTION" .Values.minecraftServer.spawnProtection  }}
-{{- template "minecraft.envMap" list "VIEW_DISTANCE" .Values.minecraftServer.viewDistance  }}
-{{- template "minecraft.envMap" list "SEED" .Values.minecraftServer.levelSeed  }}
-{{- template "minecraft.envMap" list "MODE" .Values.minecraftServer.gameMode  }}
-{{- template "minecraft.envMap" list "MOTD" .Values.minecraftServer.motd  }}
-{{- template "minecraft.envBoolMap" list "PVP" .Values.minecraftServer.pvp  }}
-{{- template "minecraft.envMap" list "LEVEL_TYPE" .Values.minecraftServer.levelType  }}
-{{- template "minecraft.envMap" list "GENERATOR_SETTINGS" .Values.minecraftServer.generatorSettings  }}
-{{- template "minecraft.envMap" list "LEVEL" .Values.minecraftServer.worldSaveName  }}
-        {{- if .Values.minecraftServer.downloadWorldUrl }}
-{{- template "minecraft.envMap" list "WORLD" .Values.minecraftServer.downloadWorldUrl  }}
-        {{- end }}
-        {{- if .Values.minecraftServer.downloadModpackUrl }}
-{{- template "minecraft.envMap" list "MODPACK" .Values.minecraftServer.downloadModpackUrl  }}
-        {{- end }}
-        {{- if .Values.minecraftServer.removeOldMods }}
-{{- template "minecraft.envMap" list "REMOVE_OLD_MODS" "true" }}
-        {{- end }}
-        {{- if .Values.minecraftServer.modUrls }}
-{{- template "minecraft.envMap" list "MODS" (join "," .Values.minecraftServer.modUrls) }}
-        {{- end }}
-        {{- if .Values.minecraftServer.pluginUrls }}
-{{- template "minecraft.envMap" list "PLUGINS" (join "," .Values.minecraftServer.pluginUrls) }}
-        {{- end }}
-        {{- if .Values.minecraftServer.spigetResources }}
-{{- template "minecraft.envMap" list "SPIGET_RESOURCES" (join "," .Values.minecraftServer.spigetResources) }}
-        {{- end }}
-
-    {{- if  .Values.minecraftServer.modrinth }}
-    {{- with .Values.minecraftServer.modrinth }}
-        {{- if .projects }}
-{{- template "minecraft.envMap" list "MODRINTH_PROJECTS" (join "," .projects) }}
-        {{- end }}
-        {{- if .optionalDependencies }}
-{{- template "minecraft.envMap" list "MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES" .optionalDependencies }}
-        {{- end }}
-{{- template "minecraft.envMap" list "MODRINTH_ALLOWED_VERSION_TYPE" .allowedVersionType }}
-    {{- end }}
-    {{- end }}
-
-        {{- if .Values.minecraftServer.vanillaTweaksShareCodes }}
-{{- template "minecraft.envMap" list "VANILLATWEAKS_SHARECODE" (join "," .Values.minecraftServer.vanillaTweaksShareCodes) }}
-        {{- end }}
-        {{- if .Values.minecraftServer.resourcePackUrl }}
-{{- template "minecraft.envMap" list "RESOURCE_PACK" .Values.minecraftServer.resourcePackUrl  }}
-        {{- end }}
-        {{- if .Values.minecraftServer.resourcePackSha }}
-{{- template "minecraft.envMap" list "RESOURCE_PACK_SHA1" .Values.minecraftServer.resourcePackSha  }}
-        {{- end }}
-        {{- if .Values.minecraftServer.resourcePackEnforce }}
-        - name: RESOURCE_PACK_ENFORCE
-          value: "TRUE"
-        {{- end }}
-{{- template "minecraft.envBoolMap" list "ONLINE_MODE" .Values.minecraftServer.onlineMode  }}
-{{- template "minecraft.envBoolMap" list "ENFORCE_SECURE_PROFILE" .Values.minecraftServer.enforceSecureProfile  }}
-{{- template "minecraft.envMap" list "MEMORY" .Values.minecraftServer.memory  }}
-{{- template "minecraft.envMap" list "JVM_OPTS" .Values.minecraftServer.jvmOpts  }}
-{{- template "minecraft.envMap" list "JVM_XX_OPTS" .Values.minecraftServer.jvmXXOpts  }}
-{{- template "minecraft.envBoolMap" list "OVERRIDE_SERVER_PROPERTIES" .Values.minecraftServer.overrideServerProperties  }}
-
-{{- if .Values.minecraftServer.rcon.enabled }}
-        - name: ENABLE_RCON
-          value: "true"
-  {{- if not .Values.minecraftServer.rcon.withGeneratedPassword }}
+        {{- with .Values.minecraftServer.rcon }}
+        {{- if and .enabled (not .withGeneratedPassword) }} # TODO: Validate functionality
         - name: RCON_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.minecraftServer.rcon.existingSecret | default (printf "%s-rcon" (include "minecraft.fullname" .)) }}
               key: {{ .Values.minecraftServer.rcon.secretKey | default "rcon-password" }}
-  {{- end }}
-{{- else }}
-        - name: ENABLE_RCON
-          value: "false"
-{{- end }}
-        {{- if .Values.minecraftServer.query.enabled }}
-        - name: ENABLE_QUERY
-          value: "true"
-{{- template "minecraft.envMap" list "QUERY_PORT" .Values.minecraftServer.query.port  }}
         {{- end }}
-
-    {{- if .Values.minecraftServer.autoCurseForge }}
-    {{- with .Values.minecraftServer.autoCurseForge }}
+        {{- end }}
+        {{- with .Values.minecraftServer.autoCurseForge }}
         - name: CF_API_KEY
           valueFrom:
             secretKeyRef:
               name: {{ .apiKey.existingSecret | default (printf "%s-curseforge" (include "minecraft.fullname" $)) }}
               key: {{ .apiKey.secretKey | default "cf-api-key" }}
-{{- template "minecraft.envMap" list "CF_PAGE_URL" .pageUrl }}
-{{- template "minecraft.envMap" list "CF_SLUG" .slug }}
-{{- template "minecraft.envMap" list "CF_FILE_ID" .fileId }}
-{{- template "minecraft.envMap" list "CF_FILENAME_MATCHER" .filenameMatcher }}
-        {{- if .excludeMods }}
-{{- template "minecraft.envMap" list "CF_EXCLUDE_MODS" (join "," .excludeMods) }}
         {{- end }}
-        {{- if .includeMods }}
-{{- template "minecraft.envMap" list "CF_FORCE_INCLUDE_MODS" (join "," .includeMods) }}
-        {{- end }}
-        {{- if not (eq nil .excludeIncludeFile) }}
-{{- template "minecraft.envMap" list "CF_EXCLUDE_INCLUDE_FILE" .excludeIncludeFile }}
-        {{- end }}
-        {{- if .forceSynchronize }}
-{{- template "minecraft.envMap" list "CF_FORCE_SYNCHRONIZE" "true" }}
-        {{- end }}
-{{- template "minecraft.envMap" list "CF_SET_LEVEL_FROM" .setLevelFrom }}
-{{- template "minecraft.envMap" list "CF_PARALLEL_DOWNLOADS" .parallelDownloads }}
-        {{- if .overridesSkipExisting }}
-{{- template "minecraft.envMap" list "CF_OVERRIDES_SKIP_EXISTING" "true" }}
-        {{- end }}
-    {{- end }}
-    {{- end }}
-
-
-      {{- range $key, $value := .Values.extraEnv }}
-      {{-   if kindIs "map" $value }}
-      {{-     if hasKey $value "valueFrom" }}
-        - name: {{ $key }}
-          valueFrom:
-            {{- $value.valueFrom | toYaml | nindent 12 }}
-      {{-     end }}
-      {{-   else }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-      {{-   end }}
-      {{- end }}
-
+        {{- template "minecraft.extraEnv" .Values.extraEnv }} # TODO: Testing and indentation checks
         ports:
         - name: minecraft
           containerPort: 25565
@@ -347,72 +198,20 @@ spec:
 {{ toYaml .Values.mcbackup.resources | indent 10 }}
       {{- with .Values.mcbackup.envFrom }}
         envFrom:
+          - configMapRef:
+              name: {{ template "minecraft.fullname" . }}-backup-config
+              optional: false
           {{- . | toYaml | nindent 10 }}{{ end }}
         env:
-        - name: SRC_DIR
-          value: "/data"
-{{- template "minecraft.envMap" list "BACKUP_NAME" .Values.minecraftServer.worldSaveName  }}
-{{- template "minecraft.envMap" list "INITIAL_DELAY" .Values.mcbackup.initialDelay  }}
-{{- template "minecraft.envMap" list "BACKUP_INTERVAL" .Values.mcbackup.backupInterval  }}
-{{- template "minecraft.envMap" list "PRUNE_BACKUPS_DAYS" .Values.mcbackup.pruneBackupsDays  }}
-{{- template "minecraft.envMap" list "PAUSE_IF_NO_PLAYERS" .Values.mcbackup.pauseIfNoPlayers  }}
-        - name: SERVER_PORT
-          value: "25565"
-        - name: RCON_HOST
-          value: "localhost"
-{{- template "minecraft.envMap" list "RCON_PORT" .Values.minecraftServer.rcon.port  }}
         - name: RCON_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.minecraftServer.rcon.existingSecret | default (printf "%s-rcon" (include "minecraft.fullname" .)) }}
               key: {{ .Values.minecraftServer.rcon.secretKey | default "rcon-password" }}
-{{- template "minecraft.envMap" list "RCON_RETRIES" .Values.mcbackup.rconRetries  }}
-{{- template "minecraft.envMap" list "RCON_RETRY_INTERVAL" .Values.mcbackup.rconRetryInterval  }}
-{{- template "minecraft.envMap" list "EXCLUDES" .Values.mcbackup.excludes  }}
-{{- template "minecraft.envMap" list "BACKUP_METHOD" .Values.mcbackup.backupMethod  }}
-        {{- if or (eq .Values.mcbackup.backupMethod "tar") (eq .Values.mcbackup.backupMethod "rclone") (eq .Values.mcbackup.backupMethod "rsync") }}
-{{- template "minecraft.envMap" list "DEST_DIR" .Values.mcbackup.destDir  }}
-{{- template "minecraft.envMap" list "LINK_LATEST" .Values.mcbackup.linkLatest  }}
-        {{- if ne .Values.mcbackup.backupMethod "rsync" }}
-{{- template "minecraft.envMap" list "TAR_COMPRESS_METHOD" .Values.mcbackup.compressMethod  }}
-{{- template "minecraft.envMap" list "ZSTD_PARAMETERS" .Values.mcbackup.zstdParameters  }}
-        {{- end }}
-        {{- if eq .Values.mcbackup.backupMethod "rclone" }}
-{{- template "minecraft.envMap" list "RCLONE_REMOTE" .Values.mcbackup.rcloneRemote  }}
-{{- template "minecraft.envMap" list "RCLONE_DEST_DIR" .Values.mcbackup.rcloneDestDir  }}
-{{- template "minecraft.envMap" list "RCLONE_COMPRESS_METHOD" .Values.mcbackup.rcloneCompressMethod  }}
-        {{- end }}
-        {{- end }}
         {{- if eq .Values.mcbackup.backupMethod "restic" }}
-{{- template "minecraft.envMap" list "RESTIC_REPOSITORY" .Values.mcbackup.resticRepository  }}
-{{- template "minecraft.envMap" list "RESTIC_ADDITIONAL_TAGS" .Values.mcbackup.resticAdditionalTags  }}
-{{- template "minecraft.envMap" list "PRUNE_RESTIC_RETENTION" .Values.mcbackup.pruneResticRetention  }}
-        {{-   range $key, $value := .Values.mcbackup.resticEnvs }}
-        {{-     if kindIs "map" $value }}
-        {{-       if hasKey $value "valueFrom" }}
-        - name: {{ $key }}
-          valueFrom:
-            {{- $value.valueFrom | toYaml | nindent 12 }}
-        {{-       end }}
-        {{-     else }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{-     end }}
-        {{-   end }}
+        {{- template "minecraft.extraEnv" .Values.mcbackup.extraEnv }} # TODO: Testing and indentation checks
         {{- end }}
-
-        {{- range $key, $value := .Values.mcbackup.extraEnv }}
-        {{-   if kindIs "map" $value }}
-        {{-     if hasKey $value "valueFrom" }}
-        - name: {{ $key }}
-          valueFrom:
-            {{- $value.valueFrom | toYaml | nindent 12 }}
-        {{-     end }}
-        {{-   else }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{-   end }}
-        {{- end }}
+        {{- template "minecraft.extraEnv" .Values.mcbackup.resticEnvs }} # TODO: Testing and indentation checks
         volumeMounts:
         - name: tmp
           mountPath: /tmp

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -17,11 +17,11 @@ metadata:
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
     app.kubernetes.io/version: "{{ .Chart.Version }}"
-  {{- if .Values.deploymentLabels }}
+    {{- if .Values.deploymentLabels }}
     {{- range $key, $value := .Values.deploymentLabels}}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-  {{- end }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.workloadAsStatefulSet }}
@@ -42,11 +42,11 @@ spec:
         app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
         app.kubernetes.io/version: "{{ .Chart.Version }}"
-      {{- if .Values.podLabels }}
+        {{- if .Values.podLabels }}
         {{- range $key, $value := .Values.podLabels}}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-      {{- end }}
+        {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
         checksum/config-backup: {{ include (print $.Template.BasePath "/config-backup.yaml") . | sha256sum }}
@@ -71,7 +71,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.initContainers }}
       initContainers:
-      {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ template "minecraft.fullname" . }}
@@ -84,14 +84,16 @@ spec:
           {{- if .Values.lifecycle.postStart }}
           postStart:
             exec:
-              command: {{- range .Values.lifecycle.postStart }}
+              command:
+              {{- range .Values.lifecycle.postStart }}
                 - {{ . }}
               {{- end }}
           {{- end }}
           {{- if .Values.lifecycle.preStop }}
           preStop:
             exec:
-              command: {{- range .Values.lifecycle.preStop }}
+              command:
+              {{- range .Values.lifecycle.preStop }}
                 - {{ . }}
               {{- end }}
           {{- end }}
@@ -129,7 +131,8 @@ spec:
           - configMapRef:
               name: {{ template "minecraft.fullname" . }}-config
               optional: false
-          {{- . | toYaml | nindent 10 }}{{ end }}
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         {{- end }}
         env:
         {{- with .Values.minecraftServer.rcon }}
@@ -191,13 +194,13 @@ spec:
         {{-   end }}
         {{- end }}
         securityContext:
-            {{- toYaml .Values.securityContext | nindent 10 }}
+          {{- toYaml .Values.securityContext | nindent 10 }}
       {{- if and .Values.mcbackup.enabled .Values.minecraftServer.rcon.enabled }}
       - name: {{ template "minecraft.fullname" . }}-mc-backup
         image: "{{ .Values.mcbackup.image.repository }}:{{ .Values.mcbackup.image.tag }}"
         imagePullPolicy: {{ .Values.mcbackup.image.pullPolicy }}
         resources:
-{{ toYaml .Values.mcbackup.resources | indent 10 }}
+          {{ toYaml .Values.mcbackup.resources | nindent 10 }}
       {{- with .Values.mcbackup.envFrom }}
         envFrom:
           - configMapRef:
@@ -257,30 +260,30 @@ spec:
       - name: tmp
         emptyDir: {}
       {{- if .Values.persistence.dataDir.enabled }}
-      {{- if .Values.persistence.dataDir.existingClaim }}
+      {{-   if .Values.persistence.dataDir.existingClaim }}
       - name: datadir
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.dataDir.existingClaim }}
-      {{- else if (not .Values.workloadAsStatefulSet) }}
+      {{-   else if (not .Values.workloadAsStatefulSet) }}
       - name: datadir
         persistentVolumeClaim:
           claimName: {{ template "minecraft.fullname" . }}-datadir
-      {{- end -}}
+      {{-   end -}}
       {{/* if persistence enabled in stateful set without existing claim, a volume claim template will be defined */}}
       {{- else }}
       - name: datadir
         emptyDir: {}
       {{- end }}
       {{- if and .Values.mcbackup.persistence.backupDir.enabled .Values.mcbackup.enabled }}
-      {{- if .Values.mcbackup.persistence.backupDir.existingClaim }}
+      {{-   if .Values.mcbackup.persistence.backupDir.existingClaim }}
       - name: backupdir
         persistentVolumeClaim:
           claimName: {{ .Values.mcbackup.persistence.backupDir.existingClaim }}
-      {{- else if (not .Values.workloadAsStatefulSet) }}
+      {{-   else if (not .Values.workloadAsStatefulSet) }}
       - name: backupdir
         persistentVolumeClaim:
           claimName: {{ template "minecraft.fullname" . }}-backupdir
-      {{- end -}}
+      {{-   end -}}
       {{/* if persistence enabled in stateful set without existing claim, a volume claim template will be defined */}}
       {{- else }}
       - name: backupdir
@@ -289,11 +292,11 @@ spec:
       {{- if or (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
       - name: rclone-secret
         secret:
-        {{- if .Values.mcbackup.rcloneConfigExistingSecret }}
+          {{- if .Values.mcbackup.rcloneConfigExistingSecret }}
           secretName: {{ .Values.mcbackup.rcloneConfigExistingSecret }}
-        {{- else }}
+          {{- else }}
           secretName: {{ template "minecraft.fullname" . }}-rclone-config
-        {{- end }}
+          {{- end }}
           items:
           - key: rclone.conf
             path: rclone.conf
@@ -308,18 +311,18 @@ spec:
       {{- range $key, $value := .Values.extraPodSpec }}
       {{ $key }}: {{ tpl $value $ }}
       {{- end }}
-    {{- if .Values.nodeSelector }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.affinity }}
+        {{ toYaml .Values.nodeSelector |n indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
+        {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-    {{- end }}
+        {{ toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
   {{- if .Values.workloadAsStatefulSet }}
   volumeClaimTemplates:
     {{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim) }}
@@ -334,27 +337,27 @@ spec:
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
           app.kubernetes.io/version: "{{ .Chart.Version }}"
         annotations:
-        {{- with .Values.persistence.annotations  }}
-        {{ toYaml . | nindent 10 }}
-        {{- end }}
-        {{- if .Values.persistence.storageClass }}
+          {{- with .Values.persistence.annotations  }}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
+          {{- if .Values.persistence.storageClass }}
           volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-        {{- else }}
+          {{- else }}
           volume.alpha.kubernetes.io/storage-class: default
-        {{- end }}
+          {{- end }}
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
             storage: {{ .Values.persistence.dataDir.Size | quote }}
-      {{- if .Values.persistence.storageClass }}
-      {{- if (eq "-" .Values.persistence.storageClass) }}
+        {{- if .Values.persistence.storageClass }}
+        {{-   if (eq "-" .Values.persistence.storageClass) }}
         storageClassName: ""
-      {{- else }}
+        {{-   else }}
         storageClassName: "{{ .Values.persistence.storageClass }}"
-      {{- end }}
-      {{- end }}
+        {{-   end }}
+        {{- end }}
     {{- end }}
     {{- if and .Values.mcbackup.persistence.backupDir.enabled (not .Values.mcbackup.persistence.backupDir.existingClaim) }}
     - metadata:
@@ -368,27 +371,27 @@ spec:
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
           app.kubernetes.io/version: "{{ .Chart.Version }}"
         annotations:
-        {{- with .Values.mcbackup.persistence.annotations  }}
-        {{ toYaml . | nindent 10 }}
-        {{- end }}
-        {{- if .Values.mcbackup.persistence.storageClass }}
+          {{- with .Values.mcbackup.persistence.annotations  }}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
+          {{- if .Values.mcbackup.persistence.storageClass }}
           volume.beta.kubernetes.io/storage-class: {{ .Values.mcbackup.persistence.storageClass | quote }}
-        {{- else }}
+          {{- else }}
           volume.alpha.kubernetes.io/storage-class: default
-        {{- end }}
+          {{- end }}
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
             storage: {{ .Values.mcbackup.persistence.backupDir.Size | quote }}
-      {{- if .Values.mcbackup.persistence.storageClass }}
-      {{- if (eq "-" .Values.mcbackup.persistence.storageClass) }}
+        {{- if .Values.mcbackup.persistence.storageClass }}
+        {{-   if (eq "-" .Values.mcbackup.persistence.storageClass) }}
         storageClassName: ""
-      {{- else }}
+        {{-   else }}
         storageClassName: "{{ .Values.mcbackup.persistence.storageClass }}"
-      {{- end }}
-      {{- end }}
+        {{-   end }}
+        {{- end }}
     {{- end }}
   {{- end }}
-{{ end }}
+{{- end }}


### PR DESCRIPTION
Opening up a conversation to rework configuration handling. After working through the `minecraft` Chart, I feel there is opportunity to simplify things the administrative side without impacting overall functionality. The intention is to make it easier to manage environment variables and reduce the overall boat within the deployment definition.

The path I'm taking here is moving environment variables into a set of configmaps, one for the server and another for mc-backup, then referencing these configmaps using `envFrom.configMapRef`. The downside to this option is usually that changing the configmap doesn't trigger a restart, but projects like ArgoCD have worked around this by [storing the configmap's hash in an annotation](https://github.com/argoproj/argo-helm/blob/e49123cdf455c7f793718be823583f4747e0918e/charts/argo-cd/templates/argocd-application-controller/deployment.yaml#L24).

Another relatively significant change that comes with these updates is that I'm passing environment variables in, regardless of their definition. What I found is that `docker-minecraft-server` does a very good job of consistently referencing environment variables in ways that treat an unassigned variable identically to the assignment of an empty string. 

In contrast, I found that `mc-image-helper` does not so smoothly handle empty string assignment. In the current implementation, `minecraftServer.forcegameMode` has a default value of `default`. When this is set, the environment variable is completely omitted. My suggested changes does not have this logic, so we effectively get `FORCE_GAMEMODE=""`. This translates to `server.properties` having `force-gamemode=`. The server does still default this properly, but it does muddle up `server.properties` in a way that may be undesirable.

There's still a decent amount of testing to be done, but wanted to open up the conversation early in the process to make sure there's agreement in the direction and intention.