### PR TITLE
Allow setting loadBalancerClass

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.22.2
+version: 4.23.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -26,6 +26,9 @@ spec:
   {{- if .Values.minecraftServer.loadBalancerIP }}
   loadBalancerIP: {{ .Values.minecraftServer.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.minecraftServer.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.minecraftServer.loadBalancerClass }}
+  {{- end }}
   {{- if .Values.minecraftServer.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
 {{ toYaml .Values.minecraftServer.loadBalancerSourceRanges | indent 4 }}

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -24,6 +24,9 @@ spec:
   type: ClusterIP
 {{- else if eq .Values.minecraftServer.rcon.serviceType "LoadBalancer" }}
   type: {{ .Values.minecraftServer.rcon.serviceType }}
+  {{- if .Values.minecraftServer.rcon.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.minecraftServer.rcon.loadBalancerClass }}
+  {{- end }}
   {{- if .Values.minecraftServer.rcon.loadBalancerIP }}
   loadBalancerIP: {{ .Values.minecraftServer.rcon.loadBalancerIP }}
   {{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -262,6 +262,7 @@ minecraftServer:
   # Set the external port of the service, usefull when using the LoadBalancer service type
   servicePort: 25565
   clusterIP:
+  loadBalancerClass:
   loadBalancerIP:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local
@@ -335,6 +336,7 @@ minecraftServer:
     ## Set the external port if the rcon serviceType is NodePort
     nodePort:
     clusterIP:
+    loadBalancerClass:
     loadBalancerIP:
     # loadBalancerSourceRanges: []
     ## Set the externalTrafficPolicy in the Service to either Cluster or Local


### PR DESCRIPTION
For services `spec.loadBalancerClass` allows you to specify a LoadBalancer implementation other than the cloud provider default:

https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class

This PR adds the ability to specify the loadBalancerClass for the Minecraft and RCON services.