### PR TITLE
Add templating to initContainers and sidecarContainers

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.23.0
+version: 4.23.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -39,7 +39,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end }}
 {{- end }}
 
-{{- define "extraDeploy.render" -}}
+{{- define "tplRender" -}}
 {{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
 {{- if contains "{{" (toJson .value) }}
   {{- if .scope }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -68,10 +68,6 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.initContainers }}
-      initContainers:
-      {{- toYaml .Values.initContainers | nindent 8 }}
-      {{- end }}
       containers:
       - name: {{ template "minecraft.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -439,11 +435,12 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
       {{- end }}
-      {{- if .Values.sidecarContainers }}
-      {{- toYaml .Values.sidecarContainers | nindent 6 }}
+      {{- range .Values.sidecarContainers }}
+      - {{ include "tplRender" (dict "value" . "context" $) | nindent 8 | trim }}
       {{- end }}
-      {{- if or (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
+      {{- if or .Values.initContainers (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
       initContainers:
+        {{- if or (eq .Values.mcbackup.backupMethod "rclone") (eq (include "isResticWithRclone" $) "true") }}
         - name: init-container
           image: busybox
           command: ['sh', '-c', 'cp /secret/rclone.conf /config/rclone/']
@@ -452,6 +449,10 @@ spec:
             mountPath: /secret
           - name: rclone-config
             mountPath: /config/rclone
+        {{- end }}
+        {{- range .Values.initContainers }}
+        - {{ include "tplRender" (dict "value" . "context" $) | nindent 10 | trim }}
+        {{- end }}
       {{- end }}
       volumes:
       - name: tmp

--- a/charts/minecraft/templates/extra-list.yaml
+++ b/charts/minecraft/templates/extra-list.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraDeploy }}
 ---
-{{ include "extraDeploy.render" (dict "value" . "context" $) }}
+{{ include "tplRender" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "required": ["minecraftServer"],
+    "required": ["minecraftServer", "initContainers", "sidecarContainers"],
     "properties": {
         "minecraftServer": {
             "type": "object",
@@ -195,6 +195,24 @@
         },
         "extraPodSpec": {
             "type": "object"
+        },
+        "initContainers": {
+            "items": {
+                "type": ["object", "string"]
+            },
+            "type": "array"
+        },
+        "sidecarContainers": {
+            "items": {
+                "type": ["object", "string"]
+            },
+            "type": "array"
+        },
+        "extraDeploy": {
+            "items": {
+                "type": ["object", "string"]
+            },
+            "type": "array"
         }
     }
 }

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -80,24 +80,46 @@ startupProbe:
   failureThreshold: 30
   periodSeconds: 10
 
+## Array of initContainers to add to include in deployment (supports templating)
+##
 # initContainers:
 #   - name: do-something
 #     image: busybox
 #     command: ['do', 'something']
-#     volumesMounts:
+#     volumeMounts:
+#       - name: nfs
+#         mountPath: /mnt/volume
+#         readOnly: true
+#   - |
+#     name: {{ template "minecraft.fullname" . }}-init
+#     image: busybox
+#     command: ['do', 'something']
+#     volumeMounts:
 #       - name: nfs
 #         mountPath: /mnt/volume
 #         readOnly: true
 initContainers: []
 
+## Array of additional sidecards to include in the deployment (supports templating)
+##
 # sidecarContainers:
 #   - name: do-something
 #     image: busybox
 #     command: ['do', 'something']
-#     volumesMounts:
+#     volumeMounts:
 #       - name: nfs
 #         mountPath: /mnt/volume
 #         readOnly: true
+#   - |
+#     name: {{ template "minecraft.fullname" . }}-sidecar
+#     image: busybox
+#     command: ['do', 'something', 'with', 'rcon']
+#     env:
+#       - name: RCON_PASSWORD
+#         valueFrom:
+#           secretKeyRef:
+#             name: '{{ .Values.minecraftServer.rcon.existingSecret | default (printf "%s-rcon" (include "minecraft.fullname" .)) }}'
+#             key: "{{ .Values.minecraftServer.rcon.secretKey | default "rcon-password" }}"
 sidecarContainers: []
 
 # extraVolumes:


### PR DESCRIPTION
Adds the ability for users to use templating within the `initContainers` and `sidecarContainers` values.

Summary of changes:
* renames existing `extraDeploy.render` helper function to `tplRender`
* removes multiple `initContainers` keys in deployment when `initContainers` is specified with rclone backups
* uses `tplRender` function to process `initContainers` and `sidecarContainers`
* add templating examples to `values.yaml`
* add `initContainers`, `sidecarContainers` and `extraDeploy` to values schema