### PR TITLE
Default image pull policy to Always

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 2.8.1
+version: 2.8.2
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -2,7 +2,7 @@
 image:
   repository: itzg/minecraft-bedrock-server
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   pullSecret: ""
 
 ## Configure resource requests and limits

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.23.2
+version: 4.23.3
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -2,7 +2,7 @@
 image:
   repository: itzg/minecraft-server
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   pullSecret: ""
 
 # ### WARNING ###


### PR DESCRIPTION
Since the default tag is "latest" and features arrive fairly frequently, it's more intuitive to have the latest image be more aggressive about checking for updates in the registry. The download itself is skipped if the latest image is already on the node, so it's a minor network penalty at pod creation time. 