### PR TITLE
Add option to disable TTY

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.23.4
+version: 4.23.5
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
       - name: {{ template "minecraft.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        tty: true
+        tty: {{ default true .Values.minecraftServer.tty }}
         stdin: true
         {{- if or (.Values.lifecycle.postStart) (.Values.lifecycle.preStop)}}
         lifecycle:

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -365,6 +365,9 @@ minecraftServer:
     ## Set the externalTrafficPolicy in the Service to either Cluster or Local
     # externalTrafficPolicy: Cluster
 
+  ## set this to false to not have colorized logs
+  tty: true
+
   extraPorts:
     []
 


### PR DESCRIPTION
Option to disable TTY for Minecraft Java servers, as described [here](https://docker-minecraft-server.readthedocs.io/en/latest/configuration/misc-options/#interactive-and-color-console).