### PR TITLE
Add support for MODRINTH_DOWNLOAD_DEPENDENCIES

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.23.7
+version: 4.24.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -204,8 +204,8 @@ spec:
         {{- if .projects }}
 {{- template "minecraft.envMap" list "MODRINTH_PROJECTS" (join "," .projects) }}
         {{- end }}
-        {{- if .optionalDependencies }}
-{{- template "minecraft.envMap" list "MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES" .optionalDependencies }}
+        {{- if .downloadDependencies }}
+{{- template "minecraft.envMap" list "MODRINTH_DOWNLOAD_DEPENDENCIES" .downloadDependencies }}
         {{- end }}
 {{- template "minecraft.envMap" list "MODRINTH_ALLOWED_VERSION_TYPE" .allowedVersionType }}
     {{- end }}

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -52,8 +52,8 @@
                             },
                             "uniqueItems": true
                         },
-                        "optionalDependencies": {
-                            "type": "boolean"
+                        "downloadDependencies": {
+                            "enum": ["none", "required", "optional"]
                         },
                         "allowedVersionType": {
                             "enum": ["release", "beta", "alpha", "default"]

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -313,8 +313,8 @@ minecraftServer:
   # A list of Modrinth project slugs with optional version after colon
   modrinth:
     projects: []
-    # Downloads Modrinth project dependencies marked as optional
-    optionalDependencies: false
+    # Specifies whether to download Modrinth dependencies. The allowed values are: none, required, optional
+    downloadDependencies: none
     # The version type is used to determine the newest version to use from each project. The allowed values are: release, beta, alpha
     allowedVersionType: default
 


### PR DESCRIPTION
Once again, thank you so much for this project!

Right now, when trying to download Modrinth plugins, there's no support for [MODRINTH_DOWNLOAD_DEPENDENCIES](https://docker-minecraft-server.readthedocs.io/en/latest/mods-and-plugins/modrinth/#extra-options). This means that there is no way to specify to download required dependencies from Modrinth and they all must be manually specified. This PR fixes that

(Note - this is my first time modifying a helm chart, so you should probably make sure there's nothing else I missed changing. This should still provide backwards compatibility, but I don't know if you would also want to bump the version number)