### PR TITLE
Fix user and group ID

### DIFF
--- a/charts/minecraft-bedrock/values.yaml
+++ b/charts/minecraft-bedrock/values.yaml
@@ -33,9 +33,9 @@ affinity: {}
 
 podSecurityContext:
   runAsUser: 1000
-  runAsGroup: 3000
+  runAsGroup: 1000
   runAsNonRoot: true
-  fsGroup: 2000
+  fsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
 


### PR DESCRIPTION
I think the current values can't work, and they don't work when using nfs-csi:
```
/opt/bedrock-entry.sh: line 30: restify.err: Permission denied
```