### PR TITLE
Fix charts.version for OCI chart rendering

### DIFF
--- a/charts/minecraft-bedrock/Chart.yaml
+++ b/charts/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-bedrock
-version: 2.8.2
+version: 2.8.3
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft-bedrock/templates/_helpers.tpl
+++ b/charts/minecraft-bedrock/templates/_helpers.tpl
@@ -7,6 +7,15 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Set the chart fullname
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the labels spec).
+We change "+" with "_" for OCI compatibility
+*/}}
+{{- define "chart.fullname" -}}
+{{- printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-") -}}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/minecraft-bedrock/templates/datadir-pvc.yaml
+++ b/charts/minecraft-bedrock/templates/datadir-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   {{- with .Values.persistence.labels  }}

--- a/charts/minecraft-bedrock/templates/datadir-pvc.yaml
+++ b/charts/minecraft-bedrock/templates/datadir-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   {{- with .Values.persistence.labels  }}

--- a/charts/minecraft-bedrock/templates/datadir-pvc.yaml
+++ b/charts/minecraft-bedrock/templates/datadir-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   {{- with .Values.persistence.labels  }}

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   {{- with .Values.deploymentLabels  }}
@@ -241,7 +241,7 @@ spec:
         name: datadir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
         annotations:

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   {{- with .Values.deploymentLabels  }}
@@ -241,7 +241,7 @@ spec:
         name: datadir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
         annotations:

--- a/charts/minecraft-bedrock/templates/deployment.yaml
+++ b/charts/minecraft-bedrock/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   {{- with .Values.deploymentLabels  }}
@@ -241,7 +241,7 @@ spec:
         name: datadir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          chart: "{{ include "chart.fullname" . }}"
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
         annotations:

--- a/charts/minecraft-bedrock/templates/minecraft-svc.yaml
+++ b/charts/minecraft-bedrock/templates/minecraft-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   {{- with .Values.serviceLabels  }}

--- a/charts/minecraft-bedrock/templates/minecraft-svc.yaml
+++ b/charts/minecraft-bedrock/templates/minecraft-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   {{- with .Values.serviceLabels  }}

--- a/charts/minecraft-bedrock/templates/minecraft-svc.yaml
+++ b/charts/minecraft-bedrock/templates/minecraft-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   {{- with .Values.serviceLabels  }}

--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 3.8.3
+version: 3.8.4
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/_helpers.tpl
+++ b/charts/minecraft-proxy/templates/_helpers.tpl
@@ -7,6 +7,15 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Set the chart fullname
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the labels spec).
+We change "+" with "_" for OCI compatibility
+*/}}
+{{- define "chart.fullname" -}}
+{{- printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-") -}}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/minecraft-proxy/templates/configmap.yaml
+++ b/charts/minecraft-proxy/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/charts/minecraft-proxy/templates/configmap.yaml
+++ b/charts/minecraft-proxy/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/charts/minecraft-proxy/templates/configmap.yaml
+++ b/charts/minecraft-proxy/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/charts/minecraft-proxy/templates/datadir-pvc.yaml
+++ b/charts/minecraft-proxy/templates/datadir-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/charts/minecraft-proxy/templates/datadir-pvc.yaml
+++ b/charts/minecraft-proxy/templates/datadir-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/charts/minecraft-proxy/templates/datadir-pvc.yaml
+++ b/charts/minecraft-proxy/templates/datadir-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations: {{ toYaml .Values.deploymentAnnotations | nindent 4 }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations: {{ toYaml .Values.deploymentAnnotations | nindent 4 }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/minecraft-proxy/templates/deployment.yaml
+++ b/charts/minecraft-proxy/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations: {{ toYaml .Values.deploymentAnnotations | nindent 4 }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/minecraft-proxy/templates/proxy-svc.yaml
+++ b/charts/minecraft-proxy/templates/proxy-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/charts/minecraft-proxy/templates/proxy-svc.yaml
+++ b/charts/minecraft-proxy/templates/proxy-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/charts/minecraft-proxy/templates/proxy-svc.yaml
+++ b/charts/minecraft-proxy/templates/proxy-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/charts/minecraft-proxy/templates/rcon-secret.yaml
+++ b/charts/minecraft-proxy/templates/rcon-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/minecraft-proxy/templates/rcon-secret.yaml
+++ b/charts/minecraft-proxy/templates/rcon-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/minecraft-proxy/templates/rcon-secret.yaml
+++ b/charts/minecraft-proxy/templates/rcon-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/minecraft-proxy/templates/rcon-svc.yaml
+++ b/charts/minecraft-proxy/templates/rcon-svc.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ toYaml .Values.rconServiceAnnotations | indent 4 }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/minecraft-proxy/templates/rcon-svc.yaml
+++ b/charts/minecraft-proxy/templates/rcon-svc.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ toYaml .Values.rconServiceAnnotations | indent 4 }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/minecraft-proxy/templates/rcon-svc.yaml
+++ b/charts/minecraft-proxy/templates/rcon-svc.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ toYaml .Values.rconServiceAnnotations | indent 4 }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/minecraft-proxy/templates/velocity-forwarding-secret.yaml
+++ b/charts/minecraft-proxy/templates/velocity-forwarding-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/minecraft-proxy/templates/velocity-forwarding-secret.yaml
+++ b/charts/minecraft-proxy/templates/velocity-forwarding-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/minecraft-proxy/templates/velocity-forwarding-secret.yaml
+++ b/charts/minecraft-proxy/templates/velocity-forwarding-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "proxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.25.0
+version: 4.25.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -7,6 +7,15 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Set the chart fullname
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the labels spec).
+We change "+" with "_" for OCI compatibility
+*/}}
+{{- define "chart.fullname" -}}
+{{- printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-") -}}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/minecraft/templates/backupdir-pvc.yaml
+++ b/charts/minecraft/templates/backupdir-pvc.yaml
@@ -6,12 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   annotations:
   {{- with .Values.mcbackup.persistence.annotations  }}
   {{ toYaml . | nindent 4 }}

--- a/charts/minecraft/templates/backupdir-pvc.yaml
+++ b/charts/minecraft/templates/backupdir-pvc.yaml
@@ -6,12 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
   annotations:
   {{- with .Values.mcbackup.persistence.annotations  }}
   {{ toYaml . | nindent 4 }}

--- a/charts/minecraft/templates/backupdir-pvc.yaml
+++ b/charts/minecraft/templates/backupdir-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"

--- a/charts/minecraft/templates/datadir-pvc.yaml
+++ b/charts/minecraft/templates/datadir-pvc.yaml
@@ -6,12 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
   {{- with .Values.persistence.labels  }}
   {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/minecraft/templates/datadir-pvc.yaml
+++ b/charts/minecraft/templates/datadir-pvc.yaml
@@ -6,12 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   {{- with .Values.persistence.labels  }}
   {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/minecraft/templates/datadir-pvc.yaml
+++ b/charts/minecraft/templates/datadir-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
@@ -531,7 +531,7 @@ spec:
         name: datadir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          chart: "{{ include "chart.fullname" . }}"
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"
@@ -565,7 +565,7 @@ spec:
         name: backupdir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          chart: "{{ include "chart.fullname" . }}"
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -12,12 +12,12 @@ metadata:
   {{- end }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
   {{- if .Values.deploymentLabels }}
     {{- range $key, $value := .Values.deploymentLabels}}
     {{ $key }}: {{ $value | quote }}
@@ -42,7 +42,7 @@ spec:
         app: {{ template "minecraft.fullname" . }}
         app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-        app.kubernetes.io/version: "{{ .Chart.Version }}"
+        app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
       {{- if .Values.podLabels }}
         {{- range $key, $value := .Values.podLabels}}
         {{ $key }}: {{ $value | quote }}
@@ -531,12 +531,12 @@ spec:
         name: datadir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-          app.kubernetes.io/version: "{{ .Chart.Version }}"
+          app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
         annotations:
         {{- with .Values.persistence.annotations  }}
         {{ toYaml . | nindent 10 }}
@@ -565,12 +565,12 @@ spec:
         name: backupdir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-          app.kubernetes.io/version: "{{ .Chart.Version }}"
+          app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
         annotations:
         {{- with .Values.mcbackup.persistence.annotations  }}
         {{ toYaml . | nindent 10 }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -12,12 +12,12 @@ metadata:
   {{- end }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   {{- if .Values.deploymentLabels }}
     {{- range $key, $value := .Values.deploymentLabels}}
     {{ $key }}: {{ $value | quote }}
@@ -42,7 +42,7 @@ spec:
         app: {{ template "minecraft.fullname" . }}
         app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-        app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+        app.kubernetes.io/version: "{{ .Chart.Version }}"
       {{- if .Values.podLabels }}
         {{- range $key, $value := .Values.podLabels}}
         {{ $key }}: {{ $value | quote }}
@@ -531,12 +531,12 @@ spec:
         name: datadir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-          app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+          app.kubernetes.io/version: "{{ .Chart.Version }}"
         annotations:
         {{- with .Values.persistence.annotations  }}
         {{ toYaml . | nindent 10 }}
@@ -565,12 +565,12 @@ spec:
         name: backupdir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-          app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+          app.kubernetes.io/version: "{{ .Chart.Version }}"
         annotations:
         {{- with .Values.mcbackup.persistence.annotations  }}
         {{ toYaml . | nindent 10 }}

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   {{- if .Values.serviceLabels }}
     {{- range $key, $value := .Values.serviceLabels}}
     {{ $key }}: {{ $value | quote }}

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
   {{- if .Values.serviceLabels }}
     {{- range $key, $value := .Values.serviceLabels}}
     {{ $key }}: {{ $value | quote }}

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "minecraft.fullname" . }}-rclone-config
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -6,12 +6,12 @@ metadata:
   name: {{ template "minecraft.fullname" . }}-rclone-config
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
 type: Opaque
 data:
   rclone.conf: |-

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -6,12 +6,12 @@ metadata:
   name: {{ template "minecraft.fullname" . }}-rclone-config
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 type: Opaque
 data:
   rclone.conf: |-

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -8,12 +8,12 @@ metadata:
 {{ toYaml .Values.rconServiceAnnotations | indent 4 }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
   {{- if .Values.rconServiceLabels }}
     {{- range $key, $value := .Values.rconServiceLabels}}
     {{ $key }}: {{ $value | quote }}

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ toYaml .Values.rconServiceAnnotations | indent 4 }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -8,12 +8,12 @@ metadata:
 {{ toYaml .Values.rconServiceAnnotations | indent 4 }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
   {{- if .Values.rconServiceLabels }}
     {{- range $key, $value := .Values.rconServiceLabels}}
     {{ $key }}: {{ $value | quote }}

--- a/charts/minecraft/templates/secrets.yaml
+++ b/charts/minecraft/templates/secrets.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
 type: Opaque
 data:
   rcon-password: {{ default "" .Values.minecraftServer.rcon.password | b64enc | quote }}
@@ -26,12 +26,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
 type: Opaque
 data:
   cf-api-key: {{ default "" .Values.minecraftServer.autoCurseForge.apiKey.key | b64enc | quote }}

--- a/charts/minecraft/templates/secrets.yaml
+++ b/charts/minecraft/templates/secrets.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 type: Opaque
 data:
   rcon-password: {{ default "" .Values.minecraftServer.rcon.password | b64enc | quote }}
@@ -26,12 +26,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 type: Opaque
 data:
   cf-api-key: {{ default "" .Values.minecraftServer.autoCurseForge.apiKey.key | b64enc | quote }}

--- a/charts/minecraft/templates/secrets.yaml
+++ b/charts/minecraft/templates/secrets.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
@@ -26,7 +26,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"


### PR DESCRIPTION
This is a prerequisite for #254

```
failed to create resource: Secret "minecraft-<name>-rcon" is invalid: [metadata.labels: Invalid value: "minecraft-4.25.0+efa491f67fbd": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'), metadata.labels: Invalid value: "4.25.0+efa491f67fbd": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]
```