### PR TITLE
OCI chart release

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -27,9 +27,9 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,21 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
-          version: v3.4.0
+          version: v3.17.2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.13
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -36,7 +36,7 @@ jobs:
         run: ct lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
         
       - name: Install LoadBalancer

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -33,17 +33,20 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.12.0
         
       - name: Install LoadBalancer
+        if: steps.list-changed.outputs.changed == 'true'
         run: |-
           kubectl config use-context kind-chart-testing
           kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml
           kubectl apply -f .github/metallb-configmap.yaml
 
       - name: Run chart-testing (install)
-        run: ct install
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,9 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
-      id-token: write # needed for signing the images with GitHub OIDC Token
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,9 +34,6 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v4
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -63,12 +60,5 @@ jobs:
               break
             fi
 
-            chart_filename=$(basename "$pkg" .tgz)
-            chart_name=$(echo "$chart_filename" | sed -E 's/-[0-9]+\.[0-9]+\.[0-9]+$//')
-            chart_version=$(echo "$chart_filename" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$')
-
-            push_output=$(helm push "${pkg}" oci://ghcr.io/${{ github.repository }}/charts 2>&1)
-            
-            digest=$(echo "$push_output" | grep -oE 'sha256:[a-f0-9]{64}')
-            cosign sign --yes "oci://ghcr.io/${{ github.repository }}/charts/$chart_name@$digest"
+            helm push "${pkg}" oci://ghcr.io/${{ github.repository }}/charts
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,16 @@ jobs:
   release:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Turnstyle
-        uses: softprops/turnstyle@v1
+        uses: softprops/turnstyle@v2
         with:
           continue-after-seconds: 180
         env:
@@ -32,11 +36,9 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Install Cosign
-        if: ${{ github.event_name != 'pull_request' }}
         uses: sigstore/cosign-installer@v3
 
       - name: Login to GitHub Container Registry
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -46,37 +48,27 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add stable https://charts.helm.sh/stable
+          helm repo update stable
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.1.0
-        with:
-          charts_repo_url: https://itzg.github.io/minecraft-server-charts0
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Iterate and Push Updated Charts to GHCR
+      ## https://github.com/helm/chart-releaser-action/issues/107#issuecomment-2133797963
+      - name: Push Charts to GHCR
         run: |
-          for chart in charts/*; do
-            if [ -d "$chart" ]; then
-              chart_name=$(basename "$chart")
-              chart_version=$(helm show chart "$chart" | grep '^version:' | awk '{print $2}')
-              oci_url="oci://ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/$chart_name"
-
-              echo "Processing $chart_name - version $chart_version"
-              echo "Target OCI URL: $oci_url"
-
-              # Check if the OCI image already exists
-              if helm pull "$oci_url" --version "$chart_version" 2>/dev/null; then
-                echo "Chart $chart_name:$chart_version already exists in GHCR, skipping..."
-                continue
-              fi
-
-              echo "New version detected, publishing..."
-              helm package "$chart"
-              helm push "${chart_name}-${chart_version}.tgz" "$oci_url"
-
-              # Sign OCI artifact with Cosign
-              echo "Signing OCI artifact..."
-              cosign sign --yes "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/$chart_name:$chart_version"
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
             fi
+
+            chart_filename=$(basename "$pkg" .tgz)
+            chart_name=$(echo "$chart_filename" | sed -E 's/-[0-9]+\.[0-9]+\.[0-9]+$//')
+            chart_version=$(echo "$chart_filename" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$')
+
+            push_output=$(helm push "${pkg}" oci://ghcr.io/${{ github.repository }}/charts 2>&1)
+            
+            digest=$(echo "$push_output" | grep -oE 'sha256:[a-f0-9]{64}')
+            cosign sign --yes "oci://ghcr.io/${{ github.repository }}/charts/$chart_name@$digest"
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,5 +60,5 @@ jobs:
               break
             fi
 
-            helm push "${pkg}" oci://ghcr.io/${{ github.repository }}/charts
+            helm push "${pkg}" oci://ghcr.io/${{ github.repository }}
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,3 @@
-
 name: Release Charts
 
 on:
@@ -28,19 +27,56 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      # See https://github.com/helm/chart-releaser-action/issues/6
+
       - name: Install Helm
-        run: |
-          curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-          chmod 700 get_helm.sh
-          ./get_helm.sh
+        uses: azure/setup-helm@v4
+
+      - name: Install Cosign
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: sigstore/cosign-installer@v3
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Add dependency chart repos
         run: |
           helm repo add stable https://charts.helm.sh/stable
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         with:
-          charts_repo_url: https://itzg.github.io/minecraft-server-charts
+          charts_repo_url: https://itzg.github.io/minecraft-server-charts0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          
+
+      - name: Iterate and Push Updated Charts to GHCR
+        run: |
+          for chart in charts/*; do
+            if [ -d "$chart" ]; then
+              chart_name=$(basename "$chart")
+              chart_version=$(helm show chart "$chart" | grep '^version:' | awk '{print $2}')
+              oci_url="oci://ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/$chart_name"
+
+              echo "Processing $chart_name - version $chart_version"
+              echo "Target OCI URL: $oci_url"
+
+              # Check if the OCI image already exists
+              if helm pull "$oci_url" --version "$chart_version" 2>/dev/null; then
+                echo "Chart $chart_name:$chart_version already exists in GHCR, skipping..."
+                continue
+              fi
+
+              echo "New version detected, publishing..."
+              helm package "$chart"
+              helm push "${chart_name}-${chart_version}.tgz" "$oci_url"
+
+              # Sign OCI artifact with Cosign
+              echo "Signing OCI artifact..."
+              cosign sign --yes "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/$chart_name:$chart_version"
+            fi
+          done

--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 3.8.4
+version: 3.9.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/extraports-ing.yaml
+++ b/charts/minecraft-proxy/templates/extraports-ing.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ $serviceName }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "minecraft.fullname" . }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 spec:

--- a/charts/minecraft-proxy/templates/extraports-svc.yaml
+++ b/charts/minecraft-proxy/templates/extraports-svc.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations: {{ toYaml .service.annotations | nindent 4 }}
   labels:
     app: {{ $serviceName }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "minecraft.fullname" . }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 spec:

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.25.1
+version: 4.26.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -16,6 +16,15 @@ We change "+" with "_" for OCI compatibility
 {{- end }}
 
 {{/*
+Set the chart version
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the labels spec).
+We change "+" with "_" for OCI compatibility
+*/}}
+{{- define "chart.version" -}}
+{{- default .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/minecraft/templates/backupdir-pvc.yaml
+++ b/charts/minecraft/templates/backupdir-pvc.yaml
@@ -6,12 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ include "chart.fullname" . }}"
+    chart: {{ template "chart.fullname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
   annotations:
   {{- with .Values.mcbackup.persistence.annotations  }}
   {{ toYaml . | nindent 4 }}

--- a/charts/minecraft/templates/datadir-pvc.yaml
+++ b/charts/minecraft/templates/datadir-pvc.yaml
@@ -6,12 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ include "chart.fullname" . }}"
+    chart: {{ template "chart.fullname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
   {{- with .Values.persistence.labels  }}
   {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -12,12 +12,12 @@ metadata:
   {{- end }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ include "chart.fullname" . }}"
+    chart: {{ template "chart.fullname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
   {{- if .Values.deploymentLabels }}
     {{- range $key, $value := .Values.deploymentLabels}}
     {{ $key }}: {{ $value | quote }}
@@ -42,7 +42,7 @@ spec:
         app: {{ template "minecraft.fullname" . }}
         app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-        app.kubernetes.io/version: "{{ .Chart.Version }}"
+        app.kubernetes.io/version: {{ template "chart.version" . }}
       {{- if .Values.podLabels }}
         {{- range $key, $value := .Values.podLabels}}
         {{ $key }}: {{ $value | quote }}
@@ -531,12 +531,12 @@ spec:
         name: datadir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ include "chart.fullname" . }}"
+          chart: {{ template "chart.fullname" . }}
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-          app.kubernetes.io/version: "{{ .Chart.Version }}"
+          app.kubernetes.io/version: {{ template "chart.version" . }}
         annotations:
         {{- with .Values.persistence.annotations  }}
         {{ toYaml . | nindent 10 }}
@@ -565,12 +565,12 @@ spec:
         name: backupdir
         labels:
           app: {{ template "minecraft.fullname" . }}
-          chart: "{{ include "chart.fullname" . }}"
+          chart: {{ template "chart.fullname" . }}
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
           app.kubernetes.io/name: "{{ .Chart.Name }}"
           app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-          app.kubernetes.io/version: "{{ .Chart.Version }}"
+          app.kubernetes.io/version: {{ template "chart.version" . }}
         annotations:
         {{- with .Values.mcbackup.persistence.annotations  }}
         {{ toYaml . | nindent 10 }}

--- a/charts/minecraft/templates/extraports-ing.yaml
+++ b/charts/minecraft/templates/extraports-ing.yaml
@@ -14,12 +14,12 @@ metadata:
   {{- end }}
   labels:
     app: {{ $serviceName }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "minecraft.fullname" . }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
     app.kubernetes.io/name: "{{ $.Chart.Name }}"
     app.kubernetes.io/instance: {{ $minecraftFullname }}
-    app.kubernetes.io/version: "{{ $.Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
 spec:
 {{- if .ingress.ingressClassName }}
   ingressClassName: {{ .ingress.ingressClassName }}

--- a/charts/minecraft/templates/extraports-svc.yaml
+++ b/charts/minecraft/templates/extraports-svc.yaml
@@ -11,12 +11,12 @@ metadata:
   annotations: {{ toYaml .service.annotations | nindent 4 }}
   labels:
     app: {{ $serviceName }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "minecraft.fullname" . }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
     app.kubernetes.io/name: "{{ $.Chart.Name }}"
     app.kubernetes.io/instance: {{ $minecraftFullname }}
-    app.kubernetes.io/version: "{{ $.Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
 spec:
 {{- if (or (eq .service.type "ClusterIP") (empty .service.type)) }}
   type: ClusterIP

--- a/charts/minecraft/templates/minecraft-svc.yaml
+++ b/charts/minecraft/templates/minecraft-svc.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ include "chart.fullname" . }}"
+    chart: {{ template "chart.fullname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
   {{- if .Values.serviceLabels }}
     {{- range $key, $value := .Values.serviceLabels}}
     {{ $key }}: {{ $value | quote }}

--- a/charts/minecraft/templates/rclone-secret.yaml
+++ b/charts/minecraft/templates/rclone-secret.yaml
@@ -6,12 +6,12 @@ metadata:
   name: {{ template "minecraft.fullname" . }}-rclone-config
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ include "chart.fullname" . }}"
+    chart: {{ template "chart.fullname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
 type: Opaque
 data:
   rclone.conf: |-

--- a/charts/minecraft/templates/rcon-svc.yaml
+++ b/charts/minecraft/templates/rcon-svc.yaml
@@ -8,12 +8,12 @@ metadata:
 {{ toYaml .Values.rconServiceAnnotations | indent 4 }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ include "chart.fullname" . }}"
+    chart: {{ template "chart.fullname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
   {{- if .Values.rconServiceLabels }}
     {{- range $key, $value := .Values.rconServiceLabels}}
     {{ $key }}: {{ $value | quote }}

--- a/charts/minecraft/templates/secrets.yaml
+++ b/charts/minecraft/templates/secrets.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ include "chart.fullname" . }}"
+    chart: {{ template "chart.fullname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
 type: Opaque
 data:
   rcon-password: {{ default "" .Values.minecraftServer.rcon.password | b64enc | quote }}
@@ -26,12 +26,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minecraft.fullname" . }}
-    chart: "{{ include "chart.fullname" . }}"
+    chart: {{ template "chart.fullname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/instance: {{ template "minecraft.fullname" . }}
-    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/version: {{ template "chart.version" . }}
 type: Opaque
 data:
   cf-api-key: {{ default "" .Values.minecraftServer.autoCurseForge.apiKey.key | b64enc | quote }}


### PR DESCRIPTION
Update the release pipeline to continue to push to the ghcr helm repository, as well as push an OCI image and sign it.

This also cleans up the chart.version reference using a template.
This publishes the objects as `ghcr.io/itzg/minecraft-server-charts/<chartname>`

Successful run: https://github.com/joryirving/minecraft-server-charts/actions/runs/13891040259/job/38862979875

OCI artifact for mc-router: https://github.com/joryirving/minecraft-server-charts/pkgs/container/minecraft-server-charts%2Fmc-router
OCI artifact for minecraft: https://github.com/joryirving/minecraft-server-charts/pkgs/container/minecraft-server-charts%2Fminecraft

I've tested it successfully in my own cluster, and the changes to chart-version work.

Unfortunately, I couldn't get cosign working:
https://github.com/joryirving/minecraft-server-charts/actions/runs/13890798966/job/38862394740#step:11:21

Closes #254