### PR TITLE
hotfix: allow rendering extra port services

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.26.0
+version: 4.26.1
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/extraports-svc.yaml
+++ b/charts/minecraft/templates/extraports-svc.yaml
@@ -11,12 +11,12 @@ metadata:
   annotations: {{ toYaml .service.annotations | nindent 4 }}
   labels:
     app: {{ $serviceName }}
-    chart: {{ template "minecraft.fullname" . }}
+    chart: {{ template "chart.fullname" $ }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
     app.kubernetes.io/name: "{{ $.Chart.Name }}"
     app.kubernetes.io/instance: {{ $minecraftFullname }}
-    app.kubernetes.io/version: {{ template "chart.version" . }}
+    app.kubernetes.io/version: {{ template "chart.version" $ }}
 spec:
 {{- if (or (eq .service.type "ClusterIP") (empty .service.type)) }}
   type: ClusterIP


### PR DESCRIPTION
When using `.Values.minecraftServer.extraPorts` with the Service resource
enabled and not embedded, template rendering is failing due to the invocation of
`minecraft.fullname` with the context being `.` instead of `$`.

This effectively fixes it.

Minimal values file to reproduce the issue on 4.26.0:

```yaml
minecraftServer:
  extraPorts:
    - name: voice-chat
      containerPort: 24454
      service:
        enabled: true
        embedded: false
        port: 24454
```

Running a `helm template` with this results in the following error:

```
Error: template: minecraft/templates/_helpers.tpl:32:14: executing "minecraft.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride
```
