### PR TITLE
fix: add catch for nil value

### DIFF
--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -3,7 +3,8 @@
 Expand the name of the chart.
 */}}
 {{- define "minecraft.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- $nameOverride := (and .Values (get .Values "nameOverride")) }}
+{{- default .Chart.Name $nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -29,10 +30,10 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "minecraft.fullname" -}}
-{{- if .Values.fullnameOverride }}
+{{- if and .Values (hasKey .Values "fullnameOverride") .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default .Chart.Name (and .Values (get .Values "nameOverride")) }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}


### PR DESCRIPTION
Add's guard for nil value for `nameOverride` and `fullnameOverride`

Fixes #262 