### PR TITLE
mc-router: use consistent image tag default

### DIFF
--- a/charts/mc-router/Chart.yaml
+++ b/charts/mc-router/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 name: mc-router
-version: 1.2.6
-appVersion: 1.20.0
+version: 1.3.0
+# not used
+appVersion: 1.0.0
 home: https://github.com/itzg/mc-router
 description: Routes Minecraft client connections to backend servers based upon the requested server address.
 keywords:

--- a/charts/mc-router/templates/deployment.yaml
+++ b/charts/mc-router/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
 {{- include "mc-router.envMap" (list "IN_KUBE_CLUSTER" "true") }}

--- a/charts/mc-router/values.yaml
+++ b/charts/mc-router/values.yaml
@@ -6,9 +6,8 @@ replicaCount: 1
 
 image:
   repository: itzg/mc-router
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: latest
+  pullPolicy: Always
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Previous behavior of defaulting to chart's appVersion was confusing and inconsistent with other charts. It would have required forever bumping the appVersion every time mc-router was released.