### PR TITLE
Add HTTPRoute support to minecraft chart

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.26.4
+version: 4.27.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/extraports-httproute.yaml
+++ b/charts/minecraft/templates/extraports-httproute.yaml
@@ -1,0 +1,35 @@
+{{- $minecraftFullname := include "minecraft.fullname" . }}
+{{- range .Values.minecraftServer.extraPorts }}
+{{- if default "" (.httproute).enabled }}
+{{- $servicePort := .service.port }}
+{{- $serviceName := printf "%s-%s" $minecraftFullname .name }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $serviceName }}
+  namespace: "{{ $.Release.Namespace }}"
+  {{- if .httproute.annotations }}
+  annotations: {{- toYaml .httproute.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    app: {{ $serviceName }}
+    chart: {{ template "chart.fullname" $ }}
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+    app.kubernetes.io/name: "{{ $.Chart.Name }}"
+    app.kubernetes.io/instance: {{ $minecraftFullname }}
+    app.kubernetes.io/version: {{ template "chart.version" $ }}
+spec:
+{{- if .httproute.parentRefs}}
+  parentRefs: {{- toYaml .httproute.parentRefs| nindent 2}}
+{{- end }}
+{{- if .httproute.hostnames}}
+  hostnames: {{- toYaml .httproute.hostnames | nindent 2}}
+{{- end }}
+  rules:
+  - backendRefs:
+    - name: {{ $serviceName }}
+      port: {{ $servicePort }}
+{{- end }}
+{{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -400,6 +400,14 @@ minecraftServer:
     #     loadBalancerSourceRanges: []
     #     externalTrafficPolicy: Cluster
     #     port: 8123
+    #   httproute:
+    #     enabled: false
+    #     hostnames:
+    #       - map.local
+    #     parentRefs:
+    #       - name: gateway
+    #         namespace: kube-system
+    #         sectionName: https
     #   ingress:
     #     ingressClassName: nginx
     #     enabled: false


### PR DESCRIPTION
I've moved from ingress to gateway and as part of that now use httproute more. This attempts to add [HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/) support to the extraports. 

Todo:
* [x] Bump chart version
* [x] Add example to values.yaml
* [ ] Validate values.schema.json with new items

