### PR TITLE
Bump version for OCI push

### DIFF
--- a/charts/rcon-web-admin/Chart.yaml
+++ b/charts/rcon-web-admin/Chart.yaml
@@ -3,7 +3,7 @@ name: rcon-web-admin
 home: https://github.com/rcon-web-admin/rcon-web-admin
 description: RCon Web UI for managing game servers
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "0.14.1-1"
 keywords:
   - game


### PR DESCRIPTION
I was unable to find `rcon-web-admin` in an OCI repository:

``` bash
> helm pull oci://ghcr.io/itzg/minecraft-server-charts/rcon-web-admin
Error: GET "https://ghcr.io/v2/itzg/minecraft-server-charts/rcon-web-admin/tags/list": response status code 404: name unknown: repository name not known to registry
```

Seems that even though [this PR](https://github.com/itzg/minecraft-server-charts/pull/256) added OCI support, the version for `rcon-web-admin` was never bumped to actually trigger an upload.

Hopefully this PR solves this.