### PR TITLE
feat: allow custom modloader versions for auto curseforge

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 5.0.0
+version: 5.1.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/examples/auto-curseforge-custom-loader.yaml
+++ b/charts/minecraft/examples/auto-curseforge-custom-loader.yaml
@@ -1,0 +1,49 @@
+# Example configuration for AUTO_CURSEFORGE with custom modloader versions
+#
+# This example demonstrates how to override modloader versions when using
+# CurseForge modpacks, which is useful when you need a newer Fabric Loader,
+# Forge, or NeoForge version than what the modpack originally specified.
+
+minecraftServer:
+  # Accept the EULA (required)
+  eula: "TRUE"
+  
+  # Set the server type to AUTO_CURSEFORGE
+  type: AUTO_CURSEFORGE
+  
+  # Configure AUTO_CURSEFORGE settings
+  autoCurseForge:
+    # CurseForge API key - get from https://console.curseforge.com/
+    # IMPORTANT: Store this in a Kubernetes secret in production!
+    apiKey:
+      key: "your-api-key-here"
+    
+    # Example: Cobblemon Fabric modpack
+    slug: "cobblemon-fabric"
+    
+    # Override the Fabric loader version from the modpack's default
+    # Example: Change from Fabric 0.16.10 to 0.16.14
+    fabricLoaderVersion: "0.16.14"
+    
+    # For Forge modpacks, you could override the Forge version:
+    # forgeVersion: "43.2.0"
+    
+    # For NeoForge modpacks, you could override the NeoForge version:
+    # neoforgeVersion: "47.1.99"
+    
+    # Other standard AUTO_CURSEFORGE options
+    parallelDownloads: 4
+    forceSynchronize: false
+
+# Recommended memory allocation for modpacks
+resources:
+  requests:
+    memory: 4Gi
+  limits:
+    memory: 6Gi
+
+# Enable persistent storage for world data
+persistence:
+  dataDir:
+    enabled: true
+    Size: 10Gi

--- a/charts/minecraft/examples/auto-curseforge-custom-loader.yaml
+++ b/charts/minecraft/examples/auto-curseforge-custom-loader.yaml
@@ -7,30 +7,24 @@
 minecraftServer:
   # Accept the EULA (required)
   eula: "TRUE"
-  
+
   # Set the server type to AUTO_CURSEFORGE
   type: AUTO_CURSEFORGE
-  
+
   # Configure AUTO_CURSEFORGE settings
   autoCurseForge:
     # CurseForge API key - get from https://console.curseforge.com/
     # IMPORTANT: Store this in a Kubernetes secret in production!
     apiKey:
       key: "your-api-key-here"
-    
+
     # Example: Cobblemon Fabric modpack
     slug: "cobblemon-fabric"
-    
-    # Override the Fabric loader version from the modpack's default
+
+    # Override the mod loader version from the modpack's default
     # Example: Change from Fabric 0.16.10 to 0.16.14
-    fabricLoaderVersion: "0.16.14"
-    
-    # For Forge modpacks, you could override the Forge version:
-    # forgeVersion: "43.2.0"
-    
-    # For NeoForge modpacks, you could override the NeoForge version:
-    # neoforgeVersion: "47.1.99"
-    
+    modLoaderVersion: "0.16.14"
+
     # Other standard AUTO_CURSEFORGE options
     parallelDownloads: 4
     forceSynchronize: false

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -280,9 +280,7 @@ spec:
         {{- if .overridesSkipExisting }}
 {{- template "minecraft.envMap" list "CF_OVERRIDES_SKIP_EXISTING" "true" }}
         {{- end }}
-{{- template "minecraft.envMap" list "CF_FABRIC_LOADER_VERSION" .fabricLoaderVersion }}
-{{- template "minecraft.envMap" list "CF_FORGE_VERSION" .forgeVersion }}
-{{- template "minecraft.envMap" list "CF_NEOFORGE_VERSION" .neoforgeVersion }}
+{{- template "minecraft.envMap" list "CF_MOD_LOADER_VERSION" .modLoaderVersion }}
     {{- end }}
     {{- end }}
 

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -280,6 +280,9 @@ spec:
         {{- if .overridesSkipExisting }}
 {{- template "minecraft.envMap" list "CF_OVERRIDES_SKIP_EXISTING" "true" }}
         {{- end }}
+{{- template "minecraft.envMap" list "CF_FABRIC_LOADER_VERSION" .fabricLoaderVersion }}
+{{- template "minecraft.envMap" list "CF_FORGE_VERSION" .forgeVersion }}
+{{- template "minecraft.envMap" list "CF_NEOFORGE_VERSION" .neoforgeVersion }}
     {{- end }}
     {{- end }}
 

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -132,13 +132,7 @@
                         "overridesSkipExisting": {
                             "type": "boolean"
                         },
-                        "fabricLoaderVersion": {
-                            "type": "string"
-                        },
-                        "forgeVersion": {
-                            "type": "string"
-                        },
-                        "neoforgeVersion": {
+                        "modLoaderVersion": {
                             "type": "string"
                         }
                     }

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -131,6 +131,15 @@
                         },
                         "overridesSkipExisting": {
                             "type": "boolean"
+                        },
+                        "fabricLoaderVersion": {
+                            "type": "string"
+                        },
+                        "forgeVersion": {
+                            "type": "string"
+                        },
+                        "neoforgeVersion": {
+                            "type": "string"
                         }
                     }
                 },

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -355,12 +355,8 @@ minecraftServer:
     # Set to skip files in modpack "overrides" folder that would replace existing files
     # NOTE: World data is always skipped if present
     overridesSkipExisting: false
-    # Override the Fabric loader version specified in the modpack
-    fabricLoaderVersion: ""
-    # Override the Forge version specified in the modpack
-    forgeVersion: ""
-    # Override the NeoForge version specified in the modpack
-    neoforgeVersion: ""
+    # Override the mod loader version specified in the modpack
+    modLoaderVersion: ""
 
   rcon:
     # If you enable this, make SURE to change your password below.

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -355,6 +355,12 @@ minecraftServer:
     # Set to skip files in modpack "overrides" folder that would replace existing files
     # NOTE: World data is always skipped if present
     overridesSkipExisting: false
+    # Override the Fabric loader version specified in the modpack
+    fabricLoaderVersion: ""
+    # Override the Forge version specified in the modpack
+    forgeVersion: ""
+    # Override the NeoForge version specified in the modpack
+    neoforgeVersion: ""
 
   rcon:
     # If you enable this, make SURE to change your password below.


### PR DESCRIPTION
Added support for custom modloader version overrides in `AUTO_CURSEFORGE` mode via new `fabricLoaderVersion`, `forgeVersion`, and `neoforgeVersion` configuration options that map to `CF_FABRIC_LOADER_VERSION`, `CF_FORGE_VERSION`, and `CF_NEOFORGE_VERSION` environment variables.

Relates to https://github.com/itzg/docker-minecraft-server/issues/2653
Relies on https://github.com/itzg/mc-image-helper/pull/670
Relies on https://github.com/itzg/docker-minecraft-server/pull/3759
