### PR TITLE
Add patch permission for StatefulSet scaling operations

### DIFF
--- a/charts/minecraft-proxy/templates/extraports-ing.yaml
+++ b/charts/minecraft-proxy/templates/extraports-ing.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ $serviceName }}
-    chart: {{ template "proxy.fullname" . }}
+    chart: {{ template "minecraft.fullname" . }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 spec:

--- a/charts/minecraft-proxy/templates/extraports-svc.yaml
+++ b/charts/minecraft-proxy/templates/extraports-svc.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations: {{ toYaml .service.annotations | nindent 4 }}
   labels:
     app: {{ $serviceName }}
-    chart: {{ template "proxy.fullname" . }}
+    chart: {{ template "minecraft.fullname" . }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 spec:


### PR DESCRIPTION
- Add 'patch' verb to ClusterRole for statefulsets resource
- Required for versionless Patch operation used in auto-scaling
- Eliminates optimistic concurrency errors during scale operations
- Bump chart version to 1.4.1

This change supports the improved scaling logic in mc-router that uses strategic merge patches instead of Get+Update, avoiding resourceVersion conflicts when StatefulSets are modified concurrently.