### PR TITLE
Fix minecraft-proxy template references in extraPorts

### DIFF
--- a/charts/minecraft-proxy/templates/extraports-ing.yaml
+++ b/charts/minecraft-proxy/templates/extraports-ing.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ $serviceName }}
-    chart: {{ template "minecraft.fullname" . }}
+    chart: {{ template "proxy.fullname" . }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 spec:

--- a/charts/minecraft-proxy/templates/extraports-svc.yaml
+++ b/charts/minecraft-proxy/templates/extraports-svc.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations: {{ toYaml .service.annotations | nindent 4 }}
   labels:
     app: {{ $serviceName }}
-    chart: {{ template "minecraft.fullname" . }}
+    chart: {{ template "proxy.fullname" . }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 spec:


### PR DESCRIPTION
- Fix extraports-svc.yaml: use 'proxy.fullname' instead of 'minecraft.fullname'
- Fix extraports-ing.yaml: use 'proxy.fullname' instead of 'minecraft.fullname'

The extraPorts feature was referencing the wrong chart template name, causing deployment failures when extraPorts were configured:

  Error: template "minecraft.fullname" not defined

This fix corrects the template references to use the proper 'proxy.fullname' template defined in the minecraft-proxy chart.