### PR TITLE
Fix websocket url load fails and added persistence 

### DIFF
--- a/charts/rcon-web-admin/Chart.yaml
+++ b/charts/rcon-web-admin/Chart.yaml
@@ -3,7 +3,7 @@ name: rcon-web-admin
 home: https://github.com/rcon-web-admin/rcon-web-admin
 description: RCon Web UI for managing game servers
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "0.14.1-1"
 keywords:
   - game

--- a/charts/rcon-web-admin/ci/test-values.yaml
+++ b/charts/rcon-web-admin/ci/test-values.yaml
@@ -1,5 +1,7 @@
 service:
-  type: LoadBalancer
+  type: ClusterIP
 
 rconWeb:
   password: test
+  rconHost: ""
+  rconPort: 0

--- a/charts/rcon-web-admin/templates/NOTES.txt
+++ b/charts/rcon-web-admin/templates/NOTES.txt
@@ -1,3 +1,5 @@
+## Configuration
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- with .Values.ingress }}
@@ -18,3 +20,15 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+2. The web UI websocket is configured to connect to localhost:4327 by default.
+   This works when accessing via LoadBalancer since the service forwards to the same pod.
+
+3. For persistence (recommended), ensure persistence.enabled=true in your values.
+
+## Troubleshooting
+
+If the websocket fails to connect, you may need to set custom websocket URLs:
+
+rconWeb:
+  websocketUrl: "ws://<your-loadbalancer-ip>:{{ add .Values.service.httpPort 1 }}"
+  websocketUrlSsl: "wss://<your-loadbalancer-ip>:{{ add .Values.service.httpPort 1 }}"

--- a/charts/rcon-web-admin/templates/db-pvc.yaml
+++ b/charts/rcon-web-admin/templates/db-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rcon-web-admin.fullname" . }}-db
+  labels:
+    {{- include "rcon-web-admin.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | default "1Gi" }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/rcon-web-admin/templates/deployment.yaml
+++ b/charts/rcon-web-admin/templates/deployment.yaml
@@ -26,8 +26,14 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
-        - name: db
-          emptyDir: {}
+         {{- if .Values.persistence.enabled }}
+         - name: db
+           persistentVolumeClaim:
+             claimName: {{ include "rcon-web-admin.fullname" . }}-db
+         {{- else }}
+         - name: db
+           emptyDir: {}
+         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -68,36 +74,10 @@ spec:
             {{- if .Values.ingress.enabled }}
             {{ $wsUrl := print .Values.ingress.host (trimSuffix "/" .Values.ingress.path) "/websocket" }}
             - name: RWA_WEBSOCKET_URL_SSL
-              value: {{ print "wss://" $wsUrl | quote }}
+              value: {{ .Values.rconWeb.websocketUrlSsl | default "ws://localhost:4327" | quote }}
             - name: RWA_WEBSOCKET_URL
-              value: {{ print "ws://" $wsUrl | quote }}
+              value: {{ .Values.rconWeb.websocketUrl | default "wss://localhost:4327" | quote }}
             {{- end }}
-          {{- if not .Values.ingress.enabled }}
-          command:
-            - '/bin/sh'
-            - '-c'
-            - |-
-              # Installing jq to parse k8s response
-              export DEBIAN_FRONTEND=noninteractive
-              apt-get -qq update >/dev/null && apt-get -qq install -y jq > /dev/null
-              # Configuring k8s API auth
-              APISERVER=https://kubernetes.default.svc
-              SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
-              NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
-              TOKEN=$(cat ${SERVICEACCOUNT}/token)
-              CACERT=${SERVICEACCOUNT}/ca.crt
-              # Querying for websocket service
-              WS_SERVICE="$(curl --silent --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/{{ .Release.Namespace }}/services/{{ include "rcon-web-admin.fullname" . }})"
-              {{- if contains "LoadBalancer" .Values.service.type }}
-              WS_IP="$(echo "$WS_SERVICE" | jq -r .status.loadBalancer.ingress[0].ip)"
-              WS_PORT="{{ .Values.service.wsPort }}"
-              {{- else }}
-              {{- fail "Selected service type is not supported"}}
-              {{- end }}
-              export RWA_WEBSOCKET_URL="ws://$WS_IP:$WS_PORT"
-              export RWA_WEBSOCKET_URL_SSL="wss://$WS_IP:$WS_PORT"
-              /usr/local/bin/node src/main.js start
-          {{- end}}
           ports:
             - name: http
               containerPort: 4326

--- a/charts/rcon-web-admin/values.yaml
+++ b/charts/rcon-web-admin/values.yaml
@@ -9,6 +9,7 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  pullSecrets: []
 
 imagePullSecrets: []
 nameOverride: ""
@@ -70,6 +71,12 @@ tolerations: []
 
 affinity: {}
 
+persistence:
+  enabled: false
+  accessModes: ReadWriteOnce
+  size: 1Gi
+  storageClass: ""
+
 rconWeb:
   # Sets the initial user as an admin
   isAdmin: false
@@ -101,3 +108,7 @@ rconWeb:
   immutableWidgetOptions: false
   # Enables 'web rcon' if supported by the game server
   websocketRcon: false
+  # The URL for the websocket connection to the game server (if websocketRcon is true)
+  websocketUrl: "ws://localhost:4327"
+  # The URL for the secure websocket connection to the game server (if websocketRcon is true)
+  websocketUrlSsl: "wss://localhost:4327"


### PR DESCRIPTION
# Fix issue #258 rcon-web-admin chart issues

## Problem Description

The rcon-web-admin chart has two critical issues that prevent it from working correctly in Kubernetes environments:

### Issue 1: Broken WebSocket URL Configuration

**Location**: Container startup script

**Problem**: The container's default ENTRYPOINT script attempts to:
1. Install `jq` via `apt-get` to parse Kubernetes API responses
2. Query the Kubernetes API to dynamically discover the LoadBalancer IP
3. Set `RWA_WEBSOCKET_URL` based on the discovered IP

This fails in most Kubernetes deployments because:
- `apt-get` may fail due to read-only root filesystems or permission issues
- Even if `jq` installation succeeds, the API call may return an empty response
- When `jq` fails, it outputs nothing, resulting in `RWA_WEBSOCKET_URL=ws://:4327` (empty host)

**Result**: The web UI loads but fails to connect to the backend websocket, showing "Invalid url for WebSocket ws://:4327"

### Issue 2: No Database Persistence

**Location**: `values.yaml` - `persistence` section

**Problem**: The chart uses an `emptyDir` volume for the database (`/opt/rcon-web-admin/db`), which means:
- All server configurations are lost on pod restart
- User settings are reset
- A new server ID is generated each restart, confusing clients

**Result**: Users must re-configure their Minecraft servers after every deployment update or pod restart.

## Solution

### Fix 1: Add Persistent Storage Support

Add proper PVC-based persistence to the values.yaml:

```yaml
persistence:
  enabled: true
  storageClass: ""        # Uses default storage class
  accessMode: ReadWriteOnce
  size: 1Gi
```

This requires updating the deployment to use a PVC instead of emptyDir.

### Fix 2: Add WebSocket URL Environment Variables

Add environment variable support for websocket configuration with sensible defaults:

```yaml
rconWeb:
  websocketUrl: "ws://localhost:4327"      # Default for internal/LB access
  websocketUrlSsl: "wss://localhost:4327"  # Default for SSL
```

**Why `localhost:4327` works**: The browser connects to the LoadBalancer IP (e.g., `http://192.168.1.100:8080`), which forwards traffic to the pod. The pod's port 4327 is exposed via the same service, so `localhost:4327` resolves correctly when accessed through the LoadBalancer.

**When to override**: If using an external proxy or ingress with different hostnames, users can set custom URLs.

### Fix 3: Update Deployment for Persistence

The deployment needs to conditionally use a PVC when persistence is enabled:

```yaml
volumes:
  {{- if .Values.persistence.enabled }}
  - name: db
    persistentVolumeClaim:
      claimName: {{ include "rcon-web-admin.fullname" . }}-db
  {{- else }}
  - name: db
    emptyDir: {}
  {{- end }}
```


### Fix 4: Remove deployment command

```diff
-       {{- if not .Values.ingress.enabled }}
-          command:
-            - '/bin/sh'
-            - '-c'
-            - |-
-              # Installing jq to parse k8s response
-              export DEBIAN_FRONTEND=noninteractive
-              apt-get -qq update >/dev/null && apt-get -qq install -y jq > /dev/null
-              # Configuring k8s API auth
-              APISERVER=https://kubernetes.default.svc
-              SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
-              NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
-              TOKEN=$(cat ${SERVICEACCOUNT}/token)
-              CACERT=${SERVICEACCOUNT}/ca.crt
-              # Querying for websocket service
-              WS_SERVICE="$(curl --silent --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/{{ .Release.Namespace }}/services/{{ include "rcon-web-admin.fullname" . }})"
-              {{- if contains "LoadBalancer" .Values.service.type }}
-              WS_IP="$(echo "$WS_SERVICE" | jq -r .status.loadBalancer.ingress[0].ip)"
-              WS_PORT="{{ .Values.service.wsPort }}"
-              {{- else }}
-              {{- fail "Selected service type is not supported"}}
-              {{- end }}
-              export RWA_WEBSOCKET_URL="ws://$WS_IP:$WS_PORT"
-              export RWA_WEBSOCKET_URL_SSL="wss://$WS_IP:$WS_PORT"
-             /usr/local/bin/node src/main.js start
-          {{- end}}
```

## Workaround for Existing Deployments

Users with existing deployments can work around these issues by:

1. **Patch the deployment with websocket URL** (using `localhost` works when accessed via LoadBalancer):
```bash
kubectl patch deployment rcon-web-rcon-web-admin \
  --namespace minecraft \
  --type=strategic \
  -p '{"spec":{"template":{"spec":{"containers":[{"name":"rcon-web-admin","env":[{"name":"RWA_WEBSOCKET_URL","value":"ws://localhost:4327"},{"name":"RWA_WEBSOCKET_URL_SSL","value":"wss://localhost:4327"}]}]}}}}'
```

2. **Add persistence**:
```bash
kubectl patch deployment rcon-web-rcon-web-admin \
  --namespace minecraft \
  --type=strategic \
  -p '{"spec":{"template":{"spec":{"volumes":[{"name":"db","persistentVolumeClaim":{"claimName":"rcon-web-db"}}]}}}}'
```

3. **Create a PVC**:
```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: rcon-web-db
spec:
  accessModes: [ReadWriteOnce]
  resources:
    requests:
      storage: 1Gi
```

## Testing

To verify the fixes:

1. Deploy with persistence enabled
2. Configure a Minecraft server in the web UI
3. Restart the deployment: `kubectl rollout restart deployment rcon-web-rcon-web-admin`
4. Verify server configuration persists after restart
5. Verify websocket connection works from browser