### PR TITLE
Add port environment var passthrough when servicePort is enabled for LoadBalancer service

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 5.1.2
+version: 5.1.3
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -156,6 +156,7 @@ spec:
 {{- template "minecraft.envMap" list "OPS" .Values.minecraftServer.ops  }}
 {{- template "minecraft.envMap" list "ICON" .Values.minecraftServer.icon  }}
 {{- template "minecraft.envMap" list "MAX_PLAYERS" .Values.minecraftServer.maxPlayers  }}
+{{- template "minecraft.envMap" list "SERVER_PORT" .Values.minecraftServer.servicePort  }}
 {{- template "minecraft.envMap" list "MAX_WORLD_SIZE" .Values.minecraftServer.maxWorldSize  }}
 {{- template "minecraft.envMap" list "ALLOW_NETHER" .Values.minecraftServer.allowNether  }}
 {{- template "minecraft.envMap" list "ANNOUNCE_PLAYER_ACHIEVEMENTS" .Values.minecraftServer.announcePlayerAchievements  }}
@@ -299,7 +300,7 @@ spec:
 
         ports:
         - name: minecraft
-          port: {{ .Values.minecraftServer.servicePort | default 25565 }}
+          containerPort: {{ .Values.minecraftServer.servicePort | default 25565 }}
           protocol: TCP
         {{- if .Values.minecraftServer.rcon.enabled }}
         - name: rcon
@@ -358,7 +359,7 @@ spec:
 {{- template "minecraft.envMap" list "PRUNE_BACKUPS_DAYS" .Values.mcbackup.pruneBackupsDays  }}
 {{- template "minecraft.envMap" list "PAUSE_IF_NO_PLAYERS" .Values.mcbackup.pauseIfNoPlayers  }}
         - name: SERVER_PORT
-          value: {{ default 25565 .Values.minecraftServer.servicePort | quote }}
+          value: "25565"
         - name: RCON_HOST
           value: "localhost"
 {{- template "minecraft.envMap" list "RCON_PORT" .Values.minecraftServer.rcon.port  }}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -299,7 +299,7 @@ spec:
 
         ports:
         - name: minecraft
-          containerPort: 25565
+          port: {{ .Values.minecraftServer.servicePort | default 25565 }}
           protocol: TCP
         {{- if .Values.minecraftServer.rcon.enabled }}
         - name: rcon
@@ -358,7 +358,7 @@ spec:
 {{- template "minecraft.envMap" list "PRUNE_BACKUPS_DAYS" .Values.mcbackup.pruneBackupsDays  }}
 {{- template "minecraft.envMap" list "PAUSE_IF_NO_PLAYERS" .Values.mcbackup.pauseIfNoPlayers  }}
         - name: SERVER_PORT
-          value: "25565"
+          value: {{ default 25565 .Values.minecraftServer.servicePort | quote }}
         - name: RCON_HOST
           value: "localhost"
 {{- template "minecraft.envMap" list "RCON_PORT" .Values.minecraftServer.rcon.port  }}


### PR DESCRIPTION
When enabling servicePort the endpoint and listening port on the MC server inside the port, both values now receive their input from servicePort