### PR TITLE
minecraft-proxy: add optional labels and annotations on PVC

### DIFF
--- a/charts/minecraft-proxy/Chart.yaml
+++ b/charts/minecraft-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft-proxy
-version: 3.9.0
+version: 3.10.0
 appVersion: SeeValues
 description: Minecraft proxy server (BungeeCord, Waterfall, Velocity, etc.)
 keywords:

--- a/charts/minecraft-proxy/templates/datadir-pvc.yaml
+++ b/charts/minecraft-proxy/templates/datadir-pvc.yaml
@@ -9,7 +9,13 @@ metadata:
     chart: "{{ include "chart.fullname" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.persistence.labels  }}
+  {{ toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
+  {{- with .Values.persistence.annotations  }}
+  {{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- if .Values.persistence.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
   {{- else }}

--- a/charts/minecraft-proxy/values.yaml
+++ b/charts/minecraft-proxy/values.yaml
@@ -261,6 +261,8 @@ extraEnv:
 #       fieldPath: status.hostIP
 
 persistence:
+  labels: {}
+  annotations: {}
   ## minecraft data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
First, thank you for all your work on the containerization of Minecraft.

Here is a small contribution for adding custom labels and annotations to the datadir PVC of the proxy.

Tell me if I can do anything,
Regards,
Maxi_Mega